### PR TITLE
Fix incorrect exponent of number of MPR pairs in HistogramDisplay

### DIFF
--- a/clumpr/HistogramDisplay.py
+++ b/clumpr/HistogramDisplay.py
@@ -36,7 +36,9 @@ def plot_histogram(plot_file, histogram, width, tree_name, d, t, l, max_x=None, 
     ax = plt.gca()
     # matplotlib sure is intuitive and easy to use!
     # Get the exponent text from the y-axis and format it into latex
-    plt.tight_layout() # A hack to make offset text updated (matplotlib bug) for this issue: https://github.com/ssantichaivekin/eMPRess/pull/29
+    # tight_layout is a hack that makes the exponent display correctly.
+    # Please refer to https://github.com/ssantichaivekin/eMPRess/pull/29
+    plt.tight_layout() 
     exponent_text = ax.get_yaxis().get_offset_text().get_text()
     if exponent_text == "":
         exponent = 0

--- a/clumpr/HistogramDisplay.py
+++ b/clumpr/HistogramDisplay.py
@@ -36,7 +36,7 @@ def plot_histogram(plot_file, histogram, width, tree_name, d, t, l, max_x=None, 
     ax = plt.gca()
     # matplotlib sure is intuitive and easy to use!
     # Get the exponent text from the y-axis and format it into latex
-    plt.tight_layout() # A hack to make offset text updated (matplotlib bug)
+    plt.tight_layout() # A hack to make offset text updated (matplotlib bug) for this issue: https://github.com/ssantichaivekin/eMPRess/pull/29
     exponent_text = ax.get_yaxis().get_offset_text().get_text()
     if exponent_text == "":
         exponent = 0

--- a/clumpr/HistogramDisplay.py
+++ b/clumpr/HistogramDisplay.py
@@ -36,7 +36,7 @@ def plot_histogram(plot_file, histogram, width, tree_name, d, t, l, max_x=None, 
     ax = plt.gca()
     # matplotlib sure is intuitive and easy to use!
     # Get the exponent text from the y-axis and format it into latex
-    # tight_layout is a hack that makes the exponent display correctly.
+    # tight_layout is a hack that makes matplotlib set yaxis offset text correctly.
     # Please refer to https://github.com/ssantichaivekin/eMPRess/pull/29
     plt.tight_layout() 
     exponent_text = ax.get_yaxis().get_offset_text().get_text()

--- a/clumpr/HistogramDisplay.py
+++ b/clumpr/HistogramDisplay.py
@@ -36,6 +36,7 @@ def plot_histogram(plot_file, histogram, width, tree_name, d, t, l, max_x=None, 
     ax = plt.gca()
     # matplotlib sure is intuitive and easy to use!
     # Get the exponent text from the y-axis and format it into latex
+    plt.tight_layout() # A hack to make offset text updated (matplotlib bug)
     exponent_text = ax.get_yaxis().get_offset_text().get_text()
     if exponent_text == "":
         exponent = 0


### PR DESCRIPTION
Problem: 
There is a bug in `plt.ticklabel_format` that does not update the yaxis offset text. Because we use the yaxis offset text to calculate the exponent, it cause the exponent to be calculated incorrectly.

Fix: 
Add `plt.tight_layout()` as a hack to make matplotlib recalculate and rerender the exponent when `ticklabel_format` runs as suggested here https://stackoverflow.com/a/31522781.

Resolves #19

<img width="898" alt="83099220-5d48f600-a072-11ea-8663-f7f585ed2516" src="https://user-images.githubusercontent.com/19219105/83100236-397eb380-a064-11ea-9ffc-ee39d762b67d.png">