### PR TITLE
Import ReconInput in DTLReconGraph.py to fix import error

### DIFF
--- a/empress/clumpr/DTLReconGraph.py
+++ b/empress/clumpr/DTLReconGraph.py
@@ -30,6 +30,7 @@ from numpy import mean
 from numpy import median as md
 
 from empress.clumpr import ReconcileMainInput, Greedy
+from empress.newickFormatReader import ReconInput
 
 from typing import Tuple, Iterator
 


### PR DESCRIPTION
`ReconInput` type hints added in `DTLReconGraph.py` in #40 are not imported. This causes a runtime error.

```
$ python empress.py -fn examples/heliconius.newick costscape -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
Traceback (most recent call last):
  File "empress.py", line 11, in <module>
    from empress.clumpr import DTLReconGraph, ClusterMain, HistogramMain
  File "/Users/santisantichaivekin/Desktop/code/eMPRess/empress/clumpr/DTLReconGraph.py", line 75, in <module>
    def DP(tree_data: ReconInput, dup_cost: float, transfer_cost: float, loss_cost: float) -> Tuple[dict, float, int, list]:  
NameError: name 'ReconInput' is not defined
```