### PR TITLE
Add github workflow to run empress_cli commands

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         pipenv install --dev
-    - name: [Not Run] Lint with flake8
+    - name: (Not Run) Lint with flake8
       run: |
         # pipenv install flake8
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         pipenv install --dev
-    - name: Lint with flake8
+    - name: [Not Run] Lint with flake8
       run: |
         # pipenv install flake8
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,46 @@
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Install dependencies and run empress
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7.6
+    - name: Install pipenv
+      uses: dschep/install-pipenv-action@v1
+    - name: Install dependencies
+      run: |
+        pipenv install --dev
+    - name: Lint with flake8
+      run: |
+        pipenv install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        pipenv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Run empress_cli help
+      run: |
+        pipenv run python empress_cli.py --help
+    - name: Run cost region example in Readme.md
+      run: |
+        python empress_cli.py -fn examples/heliconius.newick costscape -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
+    - name: Run reconcile example in Readme.md
+      run: |
+        python empress_cli.py -fn examples/heliconius.newick reconcile -d 4 -t 2 -l 0
+    - name: Run distance pair histogram example in Readme.md
+      run: |
+        python empress_cli.py -fn examples/heliconius.newick histogram --csv foo.csv --histogram bar.pdf --ynorm
+    - name: Run cluster example in Readme.md
+      run: |
+        python empress_cli.py -fn examples/heliconius.newick clumpr --median --nmprs 4 --support

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,9 +26,9 @@ jobs:
         pipenv install --dev
     - name: Lint with flake8
       run: |
-        pipenv install flake8
+        # pipenv install flake8
         # stop the build if there are Python syntax errors or undefined names
-        pipenv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # pipenv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Run empress_cli help
       run: |
         pipenv run python empress_cli.py --help

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,13 +34,13 @@ jobs:
         pipenv run python empress_cli.py --help
     - name: Run cost region example in Readme.md
       run: |
-        python empress_cli.py -fn examples/heliconius.newick costscape -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
+        pipenv run python empress_cli.py -fn examples/heliconius.newick costscape -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
     - name: Run reconcile example in Readme.md
       run: |
-        python empress_cli.py -fn examples/heliconius.newick reconcile -d 4 -t 2 -l 0
+        pipenv run python empress_cli.py -fn examples/heliconius.newick reconcile -d 4 -t 2 -l 0
     - name: Run distance pair histogram example in Readme.md
       run: |
-        python empress_cli.py -fn examples/heliconius.newick histogram --csv foo.csv --histogram bar.pdf --ynorm
+        pipenv run python empress_cli.py -fn examples/heliconius.newick histogram --csv foo.csv --histogram bar.pdf --ynorm
     - name: Run cluster example in Readme.md
       run: |
-        python empress_cli.py -fn examples/heliconius.newick clumpr --median --nmprs 4 --support
+        pipenv run python empress_cli.py -fn examples/heliconius.newick clumpr --median --nmprs 4 --support

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7.6
+        python-version: 3.8
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
     - name: Install dependencies


### PR DESCRIPTION
Add github workflow to run empress on headless mode. The workflow runs the four example empress commands on readme and check whether the commands are successful.

I also plan to have the work flow run lint to check for syntax errors. But after I do that, I see that there are still many syntax errors in the code, so I have not enabled linting in this pull request.