### PR TITLE
Add gui dtl input validation on text changed

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -241,7 +241,7 @@ class App(tk.Frame):
             self.dup_cost = 1.00
             self.trans_cost = event.ydata
             self.loss_cost = event.xdata
-            self.enable_recon_btn()
+            self.update_recon_btn()
         else:
             messagebox.showinfo("Warning", "Please click inside the axes bounds.")
 


### PR DESCRIPTION
Add dtl costs input validation on text changed. (see https://stackoverflow.com/questions/4140437/interactively-validating-entry-widget-content-in-tkinter).

<img width="400" alt="Screen Shot 2020-06-15 at 2 00 52 PM" src="https://user-images.githubusercontent.com/19219105/84705793-cbb20300-af10-11ea-8be2-23fe7b93ac8e.png">
<img width="400" alt="Screen Shot 2020-06-15 at 2 00 58 PM" src="https://user-images.githubusercontent.com/19219105/84705801-ceacf380-af10-11ea-86e7-040b47342eca.png">


This also change also disables the reconcile button when text becomes invalid. Previously, when the button is enabled, it does not become disabled when text becomes invalid.