### PR TITLE
Clean up unittests in reconcile/recon_vis

### DIFF
--- a/test/reconcile/recon_vis/test_Tree.py
+++ b/test/reconcile/recon_vis/test_Tree.py
@@ -13,7 +13,7 @@ from empress.reconcile.recon_vis.utils import dict_to_tree
 # edge1 and edge2 are the edge tuples for the branches emanating from (v1, v2).  If the branch terminates at a leaf
 # then edge1 and edge2 are both None.
 
-class TestReconBuilder(unittest.TestCase):
+class TestTree(unittest.TestCase):
     host = {'hTop': ('Top', 'm1', ('m1', 'm2'), ('m1', 'm8')),
             ('m1', 'm2'): ('m1', 'm2', ('m2', 'm3'), ('m2', 'm6')),
             ('m2', 'm3'): ('m2', 'm3', ('m3', 'm4'), ('m3', 'm5')),

--- a/test/reconcile/recon_vis/test_utils.py
+++ b/test/reconcile/recon_vis/test_utils.py
@@ -5,10 +5,10 @@ import shutil
 from empress import newickFormatReader
 from empress.reconcile.recon_vis import utils
 from empress.reconcile import DTLReconGraph
-from empress.histogram import HistogramAlgTools
+from empress.histogram import HistogramBruteForce
 from empress.reconcile.script02_gen_newick_trees import generateNewickTestsMultipleSizes
 
-class TestReconBuilder(unittest.TestCase):
+class TestUtils(unittest.TestCase):
     """
     Test the build_trees_with_temporal_order function from ReconBuilder.
     The first two test examples are temporally consistent, and next
@@ -212,7 +212,7 @@ class TestReconBuilder(unittest.TestCase):
                 parasite_tree = recon_input.parasite_tree
                 for d, t, l in itertools.product(range(1, 5), repeat=3):
                     recon_graph, _, _, best_roots = DTLReconGraph.DP(recon_input, d, t, l)
-                    for reconciliation, _ in HistogramAlgTools.BF_enumerate_MPRs(recon_graph, best_roots):
+                    for reconciliation, _ in HistogramBruteForce.BF_enumerate_MPRs(recon_graph, best_roots):
                         temporal_graph = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation)
                         ordering_dict = utils.topological_order(temporal_graph)
                         # if there is no temporal inconsistency


### PR DESCRIPTION
Change unittest class names for test_Tree and test_utils to correspond to the files they are testing. Fix import error introduced in #82 .