### PR TITLE
Modify build_trees_with_temporal_order to return ConsistencyType

### DIFF
--- a/empress/reconcile/recon_vis/recon_viewer.py
+++ b/empress/reconcile/recon_vis/recon_viewer.py
@@ -17,12 +17,15 @@ def render(host_dict, parasite_dict, recon_dict, show_internal_labels=False, sho
     :param parasite_dict:  Parasite tree represented in dictionary format
     :param recon_dict: Reconciliation represented in dictionary format
     """
-    # TODO: consistency_type is not used
-    host_tree, parasite_tree, recon, consistency_type = utils.convert_to_objects(host_dict, parasite_dict, recon_dict)
-    fig = plot_tools.FigureWrapper("Reconciliation")
-    render_host(fig, host_tree, show_internal_labels)
-    host_lookup = host_tree.name_to_node_dict()
-    render_parasite(fig, parasite_tree, recon, host_lookup, show_internal_labels, show_freq)
+    # convert host and parasite dicts to objects and populate nodes with their temporal order
+    host_tree, parasite_tree, consistency_type = utils.build_trees_with_temporal_order(host_dict, parasite_dict, recon_dict)
+    recon = utils.dict_to_reconciliation(recon_dict)
+    
+    fig = plot_tools.FigureWrapper(consistency_type)
+    if consistency_type != utils.ConsistencyType.NO_CONSISTENCY:
+        render_host(fig, host_tree, show_internal_labels)
+        host_lookup = host_tree.name_to_node_dict()
+        render_parasite(fig, parasite_tree, recon, host_lookup, show_internal_labels, show_freq)
     return fig
 
 

--- a/empress/reconcile/recon_vis/recon_viewer.py
+++ b/empress/reconcile/recon_vis/recon_viewer.py
@@ -17,7 +17,8 @@ def render(host_dict, parasite_dict, recon_dict, show_internal_labels=False, sho
     :param parasite_dict:  Parasite tree represented in dictionary format
     :param recon_dict: Reconciliation represented in dictionary format
     """
-    host_tree, parasite_tree, recon = utils.convert_to_objects(host_dict, parasite_dict, recon_dict)
+    # TODO: consistency_type is not used
+    host_tree, parasite_tree, recon, consistency_type = utils.convert_to_objects(host_dict, parasite_dict, recon_dict)
     fig = plot_tools.FigureWrapper("Reconciliation")
     render_host(fig, host_tree, show_internal_labels)
     host_lookup = host_tree.name_to_node_dict()

--- a/empress/reconcile/recon_vis/utils.py
+++ b/empress/reconcile/recon_vis/utils.py
@@ -19,19 +19,10 @@ class ConsistencyType(Enum):
     WEAK_CONSISTENCY = 2
     NO_CONSISTENCY = 3
 
-# Master utility function coverts from dictionaries to objects
+    def __repr__(self):
+        return str(self.name)
 
-def convert_to_objects(host_dict, parasite_dict, recon_dict):
-    """
-    :param host_dict - dictionary representation of host tree
-    :param parasite_dict - dictionary representation of parasite tree
-    :param recon_dict - dictionary representation of reconciliation
-    :return - corresondoing host_tree and parasite_tree Tree objects,
-        recon Reconciliation object and a ConsistencyType
-    """
-    host_tree, parasite_tree, consistency_type = build_trees_with_temporal_order(host_dict, parasite_dict, recon_dict)
-    recon = dict_to_reconciliation(recon_dict)
-    return host_tree, parasite_tree, recon, consistency_type
+# Utility functions that covert from dictionaries to objects
 
 def dict_to_tree(tree_dict: dict, tree_type: tree.TreeType) -> tree.Tree:
     """
@@ -179,7 +170,7 @@ def dict_to_recongraph(old_recon_graph: Dict[Tuple, List]):
 
 # Temporal ordering utilities
 
-def build_trees_with_temporal_order(host_tree: dict, parasite_tree: dict, reconciliation: dict,) \
+def build_trees_with_temporal_order(host_tree: dict, parasite_tree: dict, reconciliation: dict) \
         -> Tuple[tree.Tree, tree.Tree, ConsistencyType]:
     """
     This function uses topological sort to order the nodes inside host and parasite tree.


### PR DESCRIPTION
- modified `recon_vis/utils` `convert_to_objects` function to additionally return a `ConsistencyType` that indicates whether a given reconciliation is strongly consistent, weakly consistent, or not consistent

- modified the corresponding `test_utils`