### PR TITLE
Rename host_tree -> host_dict, phi -> tip_mapping

### DIFF
--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -203,10 +203,10 @@ def compute_cost_regions(recon_input: ReconInput, transfer_min: float, transfer_
     Compute the cost polygon of recon_input. The cost polygon can be used
     to create a figure that separate costs into different regions.
     """
-    parasite_tree = recon_input.parasite_dict
-    host_tree = recon_input.host_dict
+    parasite_dict = recon_input.parasite_dict
+    host_dict = recon_input.host_dict
     tip_mapping = recon_input.tip_mapping
-    cost_vectors = xscape_reconcile(parasite_tree, host_tree, tip_mapping, transfer_min, transfer_max, dup_min, dup_max)
+    cost_vectors = xscape_reconcile(parasite_dict, host_dict, tip_mapping, transfer_min, transfer_max, dup_min, dup_max)
     return CostRegionsWrapper(cost_vectors, transfer_min, transfer_max, dup_min, dup_max)
 
 

--- a/empress/recon_vis/recon_viewer.py
+++ b/empress/recon_vis/recon_viewer.py
@@ -6,13 +6,14 @@ from typing import Union
 from matplotlib import pyplot as plt
 
 from empress.recon_vis.recon import EventType
+from empress.recon_vis import tree
 from empress.recon_vis import utils, plot_tools
 from empress.recon_vis.render_settings import LEAF_NODE_COLOR, COSPECIATION_NODE_COLOR, \
     DUPLICATION_NODE_COLOR, TRANSFER_NODE_COLOR, HOST_NODE_COLOR, HOST_EDGE_COLOR, \
     PARASITE_EDGE_COLOR, VERTICAL_OFFSET, COSPECIATION_OFFSET
 
 
-def render(host_dict, parasite_dict, recon_dict, show_internal_labels=False,
+def render(host_dict: dict, parasite_dict: dict, recon_dict: dict, show_internal_labels=False,
            show_freq=False, axes: Union[plt.Axes, None] = None):
     """ Renders a reconciliation using matplotlib
     :param host_dict:  Host tree represented in dictionary format
@@ -32,7 +33,7 @@ def render(host_dict, parasite_dict, recon_dict, show_internal_labels=False,
     return fig
 
 
-def render_host(fig, host_tree, show_internal_labels):
+def render_host(fig, host_tree: tree.Tree, show_internal_labels):
     """ Renders the host tree """
     set_host_node_layout(host_tree)
     root = host_tree.root_node
@@ -148,7 +149,7 @@ def event_color(event):
     return plot_tools.BLACK
 
 
-def set_host_node_layout(host_tree):
+def set_host_node_layout(host_tree: tree.Tree):
     """
     Sets the logicalRow and logicalCol values of each Node in host_tree.
     Assumes that each host Node has its order set already and this function
@@ -167,7 +168,7 @@ def set_host_node_layout(host_tree):
     set_internal_host_nodes(host_tree.root_node)
 
 
-def set_internal_host_nodes(node):
+def set_internal_host_nodes(node: tree.Node):
     """ Helper function for set_host_node_layout. """
     if node.is_leaf():
         return

--- a/empress/recon_vis/utils.py
+++ b/empress/recon_vis/utils.py
@@ -134,14 +134,14 @@ def dict_to_reconciliation(old_recon: Dict[Tuple, List]):
 
 # Temporal ordering utilities
 
-def build_trees_with_temporal_order(host_tree: dict, parasite_tree: dict, reconciliation: dict) \
+def build_trees_with_temporal_order(host_dict: dict, parasite_dict: dict, reconciliation: dict) \
         -> Tuple[tree.Tree, tree.Tree, ConsistencyType]:
     """
     This function uses topological sort to order the nodes inside host and parasite tree.
     The output trees can be used for visualization.
     
-    :param host_tree: host tree dictionary
-    :param parasite_tree: parasite tree dictionary
+    :param host_dict: host tree dictionary
+    :param parasite_dict: parasite tree dictionary
     :param reconciliation: reconciliation dictionary
     :return: a Tree object of type HOST, a Tree object of type PARASITE, and the
              ConsistencyType of the reconciliation. If the reconciliation is either
@@ -154,20 +154,20 @@ def build_trees_with_temporal_order(host_tree: dict, parasite_tree: dict, reconc
     consistency_type = ConsistencyType.NO_CONSISTENCY
 
     # find the temporal order for host and parasite nodes using strong temporal constraints
-    temporal_graph = build_temporal_graph(host_tree, parasite_tree, reconciliation)
+    temporal_graph = build_temporal_graph(host_dict, parasite_dict, reconciliation)
     ordering_dict = topological_order(temporal_graph)
 
     if ordering_dict is not None:
         consistency_type = ConsistencyType.STRONG_CONSISTENCY
     else:
         # the reconciliation is not strongly consistent, we relax the temporal constraints
-        temporal_graph = build_temporal_graph(host_tree, parasite_tree, reconciliation, False)
+        temporal_graph = build_temporal_graph(host_dict, parasite_dict, reconciliation, False)
         ordering_dict = topological_order(temporal_graph)
         if ordering_dict is not None:
             consistency_type = ConsistencyType.WEAK_CONSISTENCY
 
-    host_tree_object = dict_to_tree(host_tree, TreeType.HOST)
-    parasite_tree_object = dict_to_tree(parasite_tree, TreeType.PARASITE)
+    host_tree_object = dict_to_tree(host_dict, TreeType.HOST)
+    parasite_tree_object = dict_to_tree(parasite_dict, TreeType.PARASITE)
 
     # if there is a valid temporal ordering, we populate the layout with the order corresponding to the node
     if consistency_type != ConsistencyType.NO_CONSISTENCY:
@@ -183,21 +183,21 @@ def build_trees_with_temporal_order(host_tree: dict, parasite_tree: dict, reconc
     else:
         return None, None, ConsistencyType.NO_CONSISTENCY
 
-def create_parent_dict(host_tree, parasite_tree):
+def create_parent_dict(host_dict: dict, parasite_dict: dict):
     """
-    :param host_tree:  host tree dictionary
-    :param parasite_tree:  parasite tree dictionary
+    :param host_dict:  host tree dictionary
+    :param parasite_dict:  parasite tree dictionary
     :return: A dictionary that maps the name of a child node to the name of its parent
              for both the host tree and the parasite tree.
     """
     parent_dict = {}
-    for edge_name in host_tree:
-        child_node = _bottom_node(host_tree[edge_name])
-        parent_node = _top_node(host_tree[edge_name])
+    for edge_name in host_dict:
+        child_node = _bottom_node(host_dict[edge_name])
+        parent_node = _top_node(host_dict[edge_name])
         parent_dict[child_node] = parent_node
-    for edge_name in parasite_tree:
-        child_node = _bottom_node(parasite_tree[edge_name])
-        parent_node = _top_node(parasite_tree[edge_name])
+    for edge_name in parasite_dict:
+        child_node = _bottom_node(parasite_dict[edge_name])
+        parent_node = _top_node(parasite_dict[edge_name])
         parent_dict[child_node] = parent_node
     return parent_dict
 
@@ -239,10 +239,10 @@ def uniquify(elements):
     """
     return list(set(elements))
 
-def build_temporal_graph(host_tree, parasite_tree, reconciliation, add_strong_constraints = True):
+def build_temporal_graph(host_dict: dict, parasite_dict: dict, reconciliation: dict, add_strong_constraints = True):
     """
-    :param host_tree:  host tree dictionary
-    :param parasite_tree:  parasite tree dictionary
+    :param host_dict:  host tree dictionary
+    :param parasite_dict:  parasite tree dictionary
     :param reconciliation:  reconciliation dictionary
     :param add_strong_constraints:  a boolean indicating whether we are using the strongest
                                     temporal constraints, i.e. adding the constraints implied
@@ -256,10 +256,10 @@ def build_temporal_graph(host_tree, parasite_tree, reconciliation, add_strong_co
         in the temporal graph.
     """
     # create a dictionary that maps each host and parasite node to its parent
-    parent = create_parent_dict(host_tree, parasite_tree)
+    parent = create_parent_dict(host_dict, parasite_dict)
     # create temporal graphs for the host and parasite tree
-    temporal_host_tree = build_formatted_tree(host_tree)
-    temporal_parasite_tree = build_formatted_tree(parasite_tree)
+    temporal_host_tree = build_formatted_tree(host_dict)
+    temporal_parasite_tree = build_formatted_tree(parasite_dict)
     # initialize the final temporal graph to the combined temporal graphs of host and parasite tree
     temporal_graph = temporal_host_tree
     temporal_graph.update(temporal_parasite_tree)
@@ -301,7 +301,7 @@ def build_temporal_graph(host_tree, parasite_tree, reconciliation, add_strong_co
 # https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
 def topological_order(temporal_graph):
     """
-    :param temporal graph: as described in the return type of build_temporal_graph
+    :param temporal_graph: as described in the return type of build_temporal_graph
     :return: A dictionary in which a key is a node tuple (name, type) as described
         in build_temporal_graph and the value is a positive integer representing its topological ordering.
         The ordering numbers are consecutive values beginning at 1.

--- a/empress/reconcile/statistics.py
+++ b/empress/reconcile/statistics.py
@@ -36,20 +36,20 @@ def _trials(recon_input: ReconInput, dup_cost: float, transfer_cost: float, loss
         costs.append(cost)
     return costs
 
-def _create_random_phi(phi : dict) -> dict:
+def _create_random_phi(tip_mapping : dict) -> dict:
     """
-    :param phi <dict> - dictionary representation of parasite tip to host tip mapping
+    :param tip_mapping <dict> - dictionary representation of parasite tip to host tip mapping
     :return: a dictionary of parasite tips to host tips that preserves the degree of
-        of the host tips in phi
+        of the host tips in tip_mapping
     """
     random_phi = {}
-    parasites = list(phi.keys())
-    hosts = list(phi.values())
+    parasites = list(tip_mapping.keys())
+    hosts = list(tip_mapping.values())
     unique_hosts = list(set(hosts))
-    parasite_count = {}   # keys are hosts, values are the number of parasites on that host wrt phi
+    parasite_count = {}   # keys are hosts, values are the number of parasites on that host wrt tip_mapping
     # computer parasite_count values
     for p in parasites:
-        h = phi[p]
+        h = tip_mapping[p]
         if h in parasite_count: parasite_count[h] += 1
         else: parasite_count[h] = 1
     for h in unique_hosts:
@@ -62,7 +62,7 @@ def _create_random_phi(phi : dict) -> dict:
 def draw_stats(ax: plt.Axes, mpr_cost: float, costs: list, pvalue: float = None):
     """
     :param ax <plt.Axes> - draw histogram on ax
-    :param mpr_cost <float> - cost of MPR for given host-parasite-phi and DTL costs
+    :param mpr_cost <float> - cost of MPR for given host-parasite-tip_mapping and DTL costs
     :param costs <list> -list of floating point costs of Monte Carlo samples
     """
     if pvalue is not None:

--- a/empress/xscape/costscape.py
+++ b/empress/xscape/costscape.py
@@ -16,7 +16,7 @@ def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
     print("Costscape %s" % xscape.PROGRAM_VERSION_TEXT)
     hostTree = newick_data.host_dict
     parasiteTree = newick_data.parasite_dict
-    phi = newick_data.tip_mapping
+    tip_mapping = newick_data.tip_mapping
     if optional.outfile == "":
         display = True
     else:
@@ -24,7 +24,7 @@ def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
 
     print("Reconciling trees...")
     startTime = time.time()
-    CVlist = reconcile.reconcile(parasiteTree, hostTree, phi, \
+    CVlist = reconcile.reconcile(parasiteTree, hostTree, tip_mapping, \
                                  transferMin, transferMax, dupMin, dupMax)
     endTime = time.time()
     elapsedTime = endTime- startTime

--- a/empress/xscape/sigscape.py
+++ b/empress/xscape/sigscape.py
@@ -30,14 +30,14 @@ def getSeed(prompt):
         except ValueError:
             print("Non-numeric input.  Please try again.")
 
-def seqTrials(parasiteTree, hostTree, phi, numTrials, 
+def seqTrials(parasiteTree, hostTree, tip_mapping, numTrials,
               switchLo, switchHi, lossLo, lossHi,
               verbose=True):
     ''' Perform numTrials randomization trials sequentially.  Although
         parTrials could be used to do this too, this function doesn't
         require the multiprocessing package and thus may be preferable
         to some users in some situation.'''
-    parasiteTips, hostTips = getTipLists(parasiteTree, hostTree, phi)
+    parasiteTips, hostTips = getTipLists(parasiteTree, hostTree, tip_mapping)
     output = []
     for t in range(numTrials):
         if verbose:
@@ -51,11 +51,11 @@ def seqTrials(parasiteTree, hostTree, phi, numTrials,
         print()               # Newline
     return output
 
-def parTrials(parasiteTree, hostTree, phi, numTrials,  \
+def parTrials(parasiteTree, hostTree, tip_mapping, numTrials,  \
               switchLo, switchHi, lossLo, lossHi, result,
               verbose=True):
     ''' Perform numTrials randomization trials in one process. '''
-    parasiteTips, hostTips = getTipLists(parasiteTree, hostTree, phi)
+    parasiteTips, hostTips = getTipLists(parasiteTree, hostTree, tip_mapping)
     output = []
     for t in range(numTrials):
         if verbose:
@@ -66,7 +66,7 @@ def parTrials(parasiteTree, hostTree, phi, numTrials,  \
                                           switchLo, switchHi, lossLo, lossHi))
     result.put(output)
 
-def parallelTrials(parasiteTree, hostTree, phi, numTrials, numProcs, \
+def parallelTrials(parasiteTree, hostTree, tip_mapping, numTrials, numProcs, \
                    switchLo, switchHi, lossLo, lossHi):
     ''' This form of dumb parallelism is required to avoid overflowing
         buffers due to a Python bug. See the stackoverflow.com
@@ -79,7 +79,7 @@ def parallelTrials(parasiteTree, hostTree, phi, numTrials, numProcs, \
         procs = []
         for p in range(numProcs):
             proc = Process(target=parTrials, \
-                       args = (parasiteTree, hostTree, phi, 1,\
+                       args = (parasiteTree, hostTree, tip_mapping, 1,\
                                switchLo, switchHi, lossLo, lossHi, result))
             procs.append(proc)
             proc.start()
@@ -89,12 +89,12 @@ def parallelTrials(parasiteTree, hostTree, phi, numTrials, numProcs, \
             output.extend(result.get())
     return output
     
-def getTipLists(parasiteTree, hostTree, phi):
+def getTipLists(parasiteTree, hostTree, tip_mapping):
     ''' Return the lists of tips in the given parasite and host trees.'''
-    parasiteTips = list(phi.keys())
+    parasiteTips = list(tip_mapping.keys())
     hostTips = []
     for p in parasiteTips:
-        h = phi[p]
+        h = tip_mapping[p]
         if not h in hostTips: hostTips.append(h)
     return parasiteTips, hostTips
 

--- a/test/recon_vis/test_utils.py
+++ b/test/recon_vis/test_utils.py
@@ -40,62 +40,62 @@ class TestUtils(unittest.TestCase):
                     continue
                 self.assertTrue(ordering_dict[node_tuple] < ordering_dict[node_tuple_child])
 
-    def check_strongly_temporally_consistent(self, host_tree, parasite_tree, reconciliation):
+    def check_strongly_temporally_consistent(self, host_dict: dict, parasite_dict: dict, reconciliation: dict):
         """
         Helper function for checking a strongly temporally consistent reconciliation has a
         topological order for the host and parasite nodes, and build_temporal_graph
         function instantiates the tree objects correctly and indicates the reconciliation
         is strongly temporally consistent
         """
-        temporal_graph = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation)
+        temporal_graph = utils.build_temporal_graph(host_dict, parasite_dict, reconciliation)
         ordering_dict = utils.topological_order(temporal_graph)
         self.assertIsNotNone(ordering_dict)
         self.check_topological_order(temporal_graph, ordering_dict)
 
-        host, parasite, consistency_type = utils.build_trees_with_temporal_order(host_tree,
-                                                                                 parasite_tree, reconciliation)
+        host, parasite, consistency_type = utils.build_trees_with_temporal_order(host_dict,
+                                                                                 parasite_dict, reconciliation)
         self.assertIsNotNone(host)
         self.assertIsNotNone(parasite)
         self.assertEqual(consistency_type, utils.ConsistencyType.STRONG_CONSISTENCY)
     
-    def check_weakly_temporally_consistent(self, host_tree, parasite_tree, reconciliation):
+    def check_weakly_temporally_consistent(self, host_dict: dict, parasite_dict: dict, reconciliation):
         """
         Helper function for checking a weakly temporally consistent reconciliation has a
         topological order for the host and parasite nodes, and build_temporal_graph
         function instantiates the tree objects correctly and indicates the reconciliation
         is weakly temporally consistent
         """
-        temporal_graph_strong = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation)
+        temporal_graph_strong = utils.build_temporal_graph(host_dict, parasite_dict, reconciliation)
         ordering_dict_strong = utils.topological_order(temporal_graph_strong)
         self.assertIsNone(ordering_dict_strong)
 
-        temporal_graph_weak = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation, False)
+        temporal_graph_weak = utils.build_temporal_graph(host_dict, parasite_dict, reconciliation, False)
         ordering_dict_weak = utils.topological_order(temporal_graph_weak)
         self.assertIsNotNone(ordering_dict_weak)
         self.check_topological_order(temporal_graph_weak, ordering_dict_weak)
 
-        host, parasite, consistency_type = utils.build_trees_with_temporal_order(host_tree,
-                                                                                 parasite_tree, reconciliation)
+        host, parasite, consistency_type = utils.build_trees_with_temporal_order(host_dict,
+                                                                                 parasite_dict, reconciliation)
         self.assertIsNotNone(host)
         self.assertIsNotNone(parasite)
         self.assertEqual(consistency_type, utils.ConsistencyType.WEAK_CONSISTENCY)
 
-    def check_temporally_inconsistent(self, host_tree, parasite_tree, reconciliation):
+    def check_temporally_inconsistent(self, host_dict, parasite_dict, reconciliation):
         """
         Helper function for checking a temporally inconsistent reconciliation does not have
         a topological order for the host and parasite nodes, and build_temporal_graph
         function returns None, None, False
         """
-        temporal_graph_strong = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation)
+        temporal_graph_strong = utils.build_temporal_graph(host_dict, parasite_dict, reconciliation)
         ordering_dict_strong = utils.topological_order(temporal_graph_strong)
         self.assertIsNone(ordering_dict_strong)
 
-        temporal_graph_weak = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation, False)
+        temporal_graph_weak = utils.build_temporal_graph(host_dict, parasite_dict, reconciliation, False)
         ordering_dict_weak = utils.topological_order(temporal_graph_weak)
         self.assertIsNone(ordering_dict_weak)
 
-        host, parasite, consistency_type = utils.build_trees_with_temporal_order(host_tree,
-                                                                                 parasite_tree, reconciliation)
+        host, parasite, consistency_type = utils.build_trees_with_temporal_order(host_dict,
+                                                                                 parasite_dict, reconciliation)
         self.assertIsNone(host)
         self.assertIsNone(parasite)
         self.assertEqual(consistency_type, utils.ConsistencyType.NO_CONSISTENCY)
@@ -105,13 +105,13 @@ class TestUtils(unittest.TestCase):
         Test build_trees_with_temporal_order on a temporally consistent reconciliation
         """
         # a temporally consistent reconciliation with simple topological order
-        host_tree = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm2')),
+        host_dict = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm2')),
         ('m0', 'm1'): ('m0', 'm1', None, None),
         ('m0', 'm2'): ('m0', 'm2', ('m2', 'm3'), ('m2', 'm4')),
         ('m2', 'm3'): ('m2', 'm3', None, None),
         ('m2', 'm4'): ('m2', 'm4', None, None)}
 
-        parasite_tree = { 'pTop': ('Top', 'n0', ('n0', 'n1'), ('n0', 'n2')),
+        parasite_dict = { 'pTop': ('Top', 'n0', ('n0', 'n1'), ('n0', 'n2')),
         ('n0', 'n1'): ('n0', 'n1', None, None),
         ('n0', 'n2'): ('n0', 'n2', ('n2', 'n3'), ('n2', 'n4')),
         ('n2', 'n3'): ('n2', 'n3', None, None),
@@ -123,14 +123,14 @@ class TestUtils(unittest.TestCase):
         ('n3', 'm4'): [('C', (None, None), (None, None))],
         ('n4', 'm4'): [('C', (None, None), (None, None))]}
 
-        self.check_strongly_temporally_consistent(host_tree, parasite_tree, reconciliation)
+        self.check_strongly_temporally_consistent(host_dict, parasite_dict, reconciliation)
 
     def test_detect_strong_consistency_2(self):
         """
         Test build_trees_with_temporal_order on another temporally consistent reconciliation
         """
         # a temporally consistent reconciliation with more complicated topological order
-        host_tree = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm4')),
+        host_dict = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm4')),
         ('m0', 'm1'): ('m0', 'm1', ('m1', 'm2'), ('m1', 'm3')),
         ('m0', 'm4'): ('m0', 'm4', ('m4', 'm5'), ('m4', 'm6')),
         ('m1', 'm2'): ('m1', 'm2', None, None),
@@ -138,7 +138,7 @@ class TestUtils(unittest.TestCase):
         ('m4', 'm5'): ('m4', 'm5', None, None),
         ('m4', 'm6'): ('m4', 'm6', None, None)}
 
-        parasite_tree = { 'pTop': ('Top', 'n0', ('n0', 'n1'), ('n0', 'n2')),
+        parasite_dict = { 'pTop': ('Top', 'n0', ('n0', 'n1'), ('n0', 'n2')),
         ('n0', 'n1'): ('n0', 'n1', ('n1', 'n5'), ('n1', 'n6')),
         ('n0', 'n2'): ('n0', 'n2', ('n2', 'n3'), ('n2', 'n4')),
         ('n1', 'n5'): ('n1', 'n5', None, None),
@@ -159,14 +159,14 @@ class TestUtils(unittest.TestCase):
         ('n5', 'm2'): [('C', (None, None), (None, None))],
         ('n6', 'm3'): [('C', (None, None), (None, None))]}
 
-        self.check_strongly_temporally_consistent(host_tree, parasite_tree, reconciliation)
+        self.check_strongly_temporally_consistent(host_dict, parasite_dict, reconciliation)
 
     def test_detect_weak_consistency(self):
         """
         Test build_trees_with_temporal_order on a temporally inconsistent reconciliation
         """
         # a reconciliation with temporal inconsistency
-        host_tree = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm4')),
+        host_dict = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm4')),
         ('m0', 'm1'): ('m0', 'm1', ('m1', 'm2'), ('m1', 'm3')),
         ('m0', 'm4'): ('m0', 'm4', ('m4', 'm5'), ('m4', 'm6')),
         ('m1', 'm2'): ('m1', 'm2', None, None),
@@ -174,7 +174,7 @@ class TestUtils(unittest.TestCase):
         ('m4', 'm5'): ('m4', 'm5', None, None),
         ('m4', 'm6'): ('m4', 'm6', None, None)}
 
-        parasite_tree = { 'pTop': ('Top', 'n0', ('n0', 'n1'), ('n0', 'n5')),
+        parasite_dict = { 'pTop': ('Top', 'n0', ('n0', 'n1'), ('n0', 'n5')),
         ('n0', 'n1'): ('n0', 'n1', ('n1', 'n2'), ('n1', 'n3')),
         ('n1', 'n3'): ('n1', 'n3', ('n3', 'n4'), ('n3', 'n6')),
         ('n1', 'n2'): ('n1', 'n2', None, None),
@@ -191,20 +191,20 @@ class TestUtils(unittest.TestCase):
         ('n6', 'm6'): [('C', (None, None), (None, None))],
         ('n3', 'm4'): [('S', ('n4', 'm5'), ('n6', 'm6'))]}
 
-        self.check_weakly_temporally_consistent(host_tree, parasite_tree, reconciliation)
+        self.check_weakly_temporally_consistent(host_dict, parasite_dict, reconciliation)
 
     def test_detect_inconsistency(self):
         """
         Test build_trees_with_temporal_order on another type of temporally inconsistent reconciliation
         """
         # a reconciliation with another type of temporal inconsistency
-        host_tree = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm2')),
+        host_dict = { 'hTop': ('Top', 'm0', ('m0', 'm1'), ('m0', 'm2')),
         ('m0', 'm1'): ('m0', 'm1', ('m1', 'm3'), ('m1', 'm4')),
         ('m1', 'm3'): ('m1', 'm3', None, None),
         ('m1', 'm4'): ('m1', 'm4', None, None),
         ('m0', 'm2'): ('m0', 'm2', None, None)}
 
-        parasite_tree = { 'pTop': ('Top', 'n0', ('n0', 'n4'), ('n0', 'n2')),
+        parasite_dict = { 'pTop': ('Top', 'n0', ('n0', 'n4'), ('n0', 'n2')),
         ('n0', 'n4'): ('n0', 'n4', None, None),
         ('n0', 'n2'): ('n0', 'n2', ('n2', 'n5'), ('n2', 'n3')),
         ('n2', 'n5'): ('n2', 'n5', None, None),
@@ -220,7 +220,7 @@ class TestUtils(unittest.TestCase):
         ('n5', 'm2'): [('C', (None, None), (None, None))],
         ('n6', 'm4'): [('C', (None, None), (None, None))]}
 
-        self.check_temporally_inconsistent(host_tree, parasite_tree, reconciliation)
+        self.check_temporally_inconsistent(host_dict, parasite_dict, reconciliation)
 
     # TODO: fix this along with the newick tree generation script
     # https://github.com/ssantichaivekin/eMPRess/issues/100
@@ -238,18 +238,18 @@ class TestUtils(unittest.TestCase):
                 if count >= self.num_examples_to_test: break
                 if newick.startswith('.'): continue
                 recon_input = input_reader.getInput(os.path.join(tree_size_Folder, newick))
-                host_tree = recon_input.host_dict
-                parasite_tree = recon_input.parasite_dict
+                host_dict = recon_input.host_dict
+                parasite_dict = recon_input.parasite_dict
                 for d, t, l in itertools.product(range(1, 5), repeat=3):
                     recon_graph, _, _, best_roots = recongraph_tools.DP(recon_input, d, t, l)
                     for reconciliation, _ in histogram_brute_force.BF_enumerate_MPRs(recon_graph, best_roots):
-                        temporal_graph = utils.build_temporal_graph(host_tree, parasite_tree, reconciliation)
+                        temporal_graph = utils.build_temporal_graph(host_dict, parasite_dict, reconciliation)
                         ordering_dict = utils.topological_order(temporal_graph)
                         # the reconciliation is strongly consistent
                         if ordering_dict is not None:
                             self.check_topological_order(temporal_graph, ordering_dict)
                         else:
-                            temporal_graph = utils.build_temporal_graph(host_tree, parasite_tree,
+                            temporal_graph = utils.build_temporal_graph(host_dict, parasite_dict,
                                                                         reconciliation, False)
                             ordering_dict = utils.topological_order(temporal_graph)
                             # the reconciliation is weakly consistent


### PR DESCRIPTION
Rename host_tree -> host_dict, parasite_tree -> parasite_dict in the places where we use a dict instead of a tree object. Rename phi -> tip_mapping.