### PR TITLE
Add boolean options to Reconciliation.draw

### DIFF
--- a/draw/draw_empress_wrapper.py
+++ b/draw/draw_empress_wrapper.py
@@ -36,6 +36,11 @@ example_strong_consistent_reconciliation = empress.ReconciliationWrapper(
         parasite_distances=None,
         tip_mapping=None,
     ),
+    event_scores={
+        ('D', ('n1', 'm4'), ('n2', 'm4')): 0.5,
+        ('D', ('n3', 'm4'), ('n4', 'm4')): 0.5,
+        ('C', (None, None), (None, None)): 0.5,
+    },
     dup_cost=None,
     trans_cost=None,
     loss_cost=None,
@@ -68,6 +73,12 @@ example_inconsistent_reconciliation = empress.ReconciliationWrapper(
         parasite_distances=None,
         tip_mapping=None,
     ),
+    event_scores={
+        ('T', ('n4', 'm4'), ('n2', 'm2')): 0.5,
+        ('T', ('n5', 'm2'), ('n3', 'm1')): 0.5,
+        ('S', ('n1', 'm3'), ('n6', 'm4')): 0.5,
+        ('C', (None, None), (None, None)): 0.5,
+    },
     dup_cost=None,
     trans_cost=None,
     loss_cost=None,
@@ -90,11 +101,23 @@ def test_recongraph_draw_graph():
 
 test_recongraph_draw_graph()
 
-def test_strong_consistency_reconciliation_draw():
+def test_strong_consistency_reconciliation_draw_default():
     fig = example_strong_consistent_reconciliation.draw()
-    fig.savefig(Path(common.output_path).joinpath("test_strong_consistency_reconciliation_draw.png"))
+    fig.savefig(Path(common.output_path).joinpath("test_strong_consistency_reconciliation_draw_default.png"))
 
-test_strong_consistency_reconciliation_draw()
+test_strong_consistency_reconciliation_draw_default()
+
+def test_strong_consistency_reconciliation_draw_show_label_and_freq():
+    fig = example_strong_consistent_reconciliation.draw(show_internal_labels=True, show_freq=True)
+    fig.savefig(Path(common.output_path).joinpath("test_strong_consistency_reconciliation_draw_show_label_and_freq.png"))
+
+test_strong_consistency_reconciliation_draw_show_label_and_freq()
+
+def test_strong_consistency_reconciliation_draw_hide_label_and_freq():
+    fig = example_strong_consistent_reconciliation.draw(show_internal_labels=False, show_freq=False)
+    fig.savefig(Path(common.output_path).joinpath("test_strong_consistency_reconciliation_draw_hide_label_and_freq.png"))
+
+test_strong_consistency_reconciliation_draw_hide_label_and_freq()
 
 def test_inconsistent_reconciliation_draw():
     fig = example_inconsistent_reconciliation.draw()
@@ -102,6 +125,19 @@ def test_inconsistent_reconciliation_draw():
 
 test_inconsistent_reconciliation_draw()
 
+
+def test_cluster_reconciliation_draw():
+    recon_input = empress.ReconInputWrapper.from_files(example_host, example_parasite, example_mapping)
+    recongraph = recon_input.reconcile(1, 1, 1)
+    clusters = recongraph.cluster(3)
+    fig, axs = plt.subplots(1, len(clusters))
+    for i in range(len(clusters)):
+        median_recon = clusters[i].median()
+        median_recon.draw_on(axs[i])
+
+    fig.savefig(Path(common.output_path).joinpath("test_cluster_reconciliation_draw.png"))
+
+test_cluster_reconciliation_draw()
 
 def test_cluster_reconciliation_draw():
     recon_input = empress.ReconInputWrapper.from_files(example_host, example_parasite, example_mapping)
@@ -145,12 +181,12 @@ def test_stats_1():
 
 test_stats_1()
 
-def test_recon_input_draw_tanglegram():
+def test_recon_input_draw_tanglegram_1():
     recon_input = empress.ReconInputWrapper.from_files(example_host, example_parasite, example_mapping)
     fig = recon_input.draw()
-    fig.savefig(Path(common.output_path).joinpath("test_recon_input_draw_tanglegram.png"))
+    fig.savefig(Path(common.output_path).joinpath("test_recon_input_draw_tanglegram_1.png"))
 
-test_recon_input_draw_tanglegram()
+test_recon_input_draw_tanglegram_1()
 
 def test_recon_input_draw_tanglegram_2():
     recon_input = empress.ReconInputWrapper.from_files(example_host, example_parasite, example_mapping)

--- a/draw/draw_empress_wrapper.py
+++ b/draw/draw_empress_wrapper.py
@@ -40,11 +40,11 @@ example_strong_consistent_reconciliation = empress.ReconciliationWrapper(
     trans_cost=None,
     loss_cost=None,
     total_cost=None,
-    event_scores={
-        ('D', ('n1', 'm4'), ('n2', 'm4')): 0.5,
-        ('D', ('n3', 'm4'), ('n4', 'm4')): 0.5,
-        ('C', (None, None), (None, None)): 0.5,
-    },
+    # event_scores={
+    #     ('D', ('n1', 'm4'), ('n2', 'm4')): 0.5,
+    #     ('D', ('n3', 'm4'), ('n4', 'm4')): 0.5,
+    #     ('C', (None, None), (None, None)): 0.5,
+    # },
 )
 
 example_inconsistent_reconciliation = empress.ReconciliationWrapper(

--- a/draw/draw_empress_wrapper.py
+++ b/draw/draw_empress_wrapper.py
@@ -36,15 +36,15 @@ example_strong_consistent_reconciliation = empress.ReconciliationWrapper(
         parasite_distances=None,
         tip_mapping=None,
     ),
+    dup_cost=None,
+    trans_cost=None,
+    loss_cost=None,
+    total_cost=None,
     event_scores={
         ('D', ('n1', 'm4'), ('n2', 'm4')): 0.5,
         ('D', ('n3', 'm4'), ('n4', 'm4')): 0.5,
         ('C', (None, None), (None, None)): 0.5,
     },
-    dup_cost=None,
-    trans_cost=None,
-    loss_cost=None,
-    total_cost=None,
 )
 
 example_inconsistent_reconciliation = empress.ReconciliationWrapper(
@@ -73,16 +73,16 @@ example_inconsistent_reconciliation = empress.ReconciliationWrapper(
         parasite_distances=None,
         tip_mapping=None,
     ),
+    dup_cost=None,
+    trans_cost=None,
+    loss_cost=None,
+    total_cost=None,
     event_scores={
         ('T', ('n4', 'm4'), ('n2', 'm2')): 0.5,
         ('T', ('n5', 'm2'), ('n3', 'm1')): 0.5,
         ('S', ('n1', 'm3'), ('n6', 'm4')): 0.5,
         ('C', (None, None), (None, None)): 0.5,
     },
-    dup_cost=None,
-    trans_cost=None,
-    loss_cost=None,
-    total_cost=None,
 )
 
 def test_recongraph_draw():

--- a/draw/draw_empress_wrapper.py
+++ b/draw/draw_empress_wrapper.py
@@ -40,11 +40,11 @@ example_strong_consistent_reconciliation = empress.ReconciliationWrapper(
     trans_cost=None,
     loss_cost=None,
     total_cost=None,
-    # event_scores={
-    #     ('D', ('n1', 'm4'), ('n2', 'm4')): 0.5,
-    #     ('D', ('n3', 'm4'), ('n4', 'm4')): 0.5,
-    #     ('C', (None, None), (None, None)): 0.5,
-    # },
+    event_scores={
+        ('D', ('n1', 'm4'), ('n2', 'm4')): 0.5,
+        ('D', ('n3', 'm4'), ('n4', 'm4')): 0.5,
+        ('C', (None, None), (None, None)): 0.5,
+    },
 )
 
 example_inconsistent_reconciliation = empress.ReconciliationWrapper(

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -93,7 +93,7 @@ class ReconciliationWrapper(Drawable):
 
     def draw_on(self, axes: plt.Axes, show_internal_labels: bool = False, show_freq: bool = True):
         recon_viewer.render(self.recon_input.host_dict, self.recon_input.parasite_dict, self._reconciliation,
-                            self.event_scores, show_internal_labels=show_internal_labels, show_freq=show_freq,
+                            self.event_frequencies, show_internal_labels=show_internal_labels, show_freq=show_freq,
                             axes=axes)
 
     def count_events(self) -> Tuple[int, int, int, int]:

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -76,7 +76,7 @@ class ReconciliationWrapper(Drawable):
     # TODO: Replace dict with Reconciliation type
     # https://github.com/ssantichaivekin/eMPRess/issues/30
     def __init__(self, reconciliation: dict, root: tuple, recon_input: _ReconInput, dup_cost, trans_cost, loss_cost,
-                 total_cost: float, event_scores: Dict[tuple, float] = None):
+                 total_cost: float, event_scores: Dict[tuple, float]):
         self.recon_input = recon_input
         self.dup_cost = dup_cost
         self.trans_cost = trans_cost

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -57,18 +57,18 @@ class Drawable(ABC):
     """
 
     @abstractmethod
-    def draw_on(self, axes: plt.Axes, **kwargs):
+    def draw_on(self, axes: plt.Axes):
         """
         Draw self on matplotlib Axes
         """
         pass
 
-    def draw(self, **kwargs) -> plt.Figure:
+    def draw(self) -> plt.Figure:
         """
         Draw self as matplotlib Figure.
         """
         figure, ax = plt.subplots(1, 1)
-        self.draw_on(ax, **kwargs)
+        self.draw_on(ax)
         return figure
 
 
@@ -86,8 +86,14 @@ class ReconciliationWrapper(Drawable):
         self.root = root
         self.event_scores = event_scores
 
-    def draw_on(self, axes: plt.Axes):
+    def draw(self, show_internal_labels: bool = False, show_freq: bool = True):
+        figure, ax = plt.subplots(1, 1)
+        self.draw_on(ax, show_internal_labels=show_internal_labels, show_freq=show_freq)
+        return figure
+
+    def draw_on(self, axes: plt.Axes, show_internal_labels: bool = False, show_freq: bool = True):
         recon_viewer.render(self.recon_input.host_dict, self.recon_input.parasite_dict, self._reconciliation,
+                            self.event_scores, show_internal_labels=show_internal_labels, show_freq=show_freq,
                             axes=axes)
 
     def count_events(self) -> Tuple[int, int, int, int]:

--- a/empress/recon_vis/recon_viewer.py
+++ b/empress/recon_vis/recon_viewer.py
@@ -120,7 +120,6 @@ def render_parasite_node(fig, node, event, show_internal_labels=False, show_freq
     node_xy = (node.layout.x, node.layout.y)
     render_color = event_color(event)
     fig.dot(node_xy, render_color)
-    fig.text(node_xy, node.name, render_color)
     if show_internal_labels:
         fig.text(node_xy, node.name, render_color)
     if show_freq:


### PR DESCRIPTION
Add boolean options `show_internal_labels`, `show_freq` for `Reconciliation.draw(...)`, `Reconciliation.draw_on(...)`.

Remove the bug where we show parasite internal labels even when the parameter is set to false. Resolves #115 .