### PR TITLE
Refactor command line interface

### DIFF
--- a/.github/workflows/integration-tests-and-draw-tests.yml
+++ b/.github/workflows/integration-tests-and-draw-tests.yml
@@ -40,16 +40,16 @@ jobs:
         pipenv run python empress_cli.py cost_regions --help
     - name: Run cost region example in Readme.md
       run: |
-        pipenv run python empress_cli.py cost_regions --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
+        pipenv run python empress_cli.py cost_regions examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
     - name: Run reconcile example in Readme.md
       run: |
-        pipenv run python empress_cli.py reconcile --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -d 4 -t 2 -l 0
+        pipenv run python empress_cli.py reconcile examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping -d 4 -t 2 -l 0
     - name: Run distance pair histogram example in Readme.md
       run: |
-        pipenv run python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping --csv foo.csv --histogram bar.pdf --ynorm
+        pipenv run python empress_cli.py histogram examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping --csv foo.csv --histogram bar.pdf --ynorm
     - name: Run cluster example in Readme.md
       run: |
-        pipenv run python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -n 3 --median --n-splits 4 --support
+        pipenv run python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping 3 --median --n-splits 4 --support
     - name: Run draw examples for empress wrapper
       run: |
         pipenv run python -m draw.draw_empress_wrapper

--- a/.github/workflows/integration-tests-and-draw-tests.yml
+++ b/.github/workflows/integration-tests-and-draw-tests.yml
@@ -49,7 +49,7 @@ jobs:
         pipenv run python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping --csv foo.csv --histogram bar.pdf --ynorm
     - name: Run cluster example in Readme.md
       run: |
-        pipenv run python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -k 3 --median --nsplits 4 --support
+        pipenv run python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -n 3 --median --n-splits 4 --support
     - name: Run draw examples for empress wrapper
       run: |
         pipenv run python -m draw.draw_empress_wrapper

--- a/.github/workflows/integration-tests-and-draw-tests.yml
+++ b/.github/workflows/integration-tests-and-draw-tests.yml
@@ -35,18 +35,21 @@ jobs:
     - name: Run empress_cli help
       run: |
         pipenv run python empress_cli.py --help
+    - name: Run cost_regions help
+      run: |
+        pipenv run python empress_cli.py cost_regions --help
     - name: Run cost region example in Readme.md
       run: |
-        pipenv run python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping costscape -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
+        pipenv run python empress_cli.py cost_regions --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
     - name: Run reconcile example in Readme.md
       run: |
-        pipenv run python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping reconcile -d 4 -t 2 -l 0
+        pipenv run python empress_cli.py reconcile --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -d 4 -t 2 -l 0
     - name: Run distance pair histogram example in Readme.md
       run: |
-        pipenv run python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping histogram --csv foo.csv --histogram bar.pdf --ynorm
+        pipenv run python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping --csv foo.csv --histogram bar.pdf --ynorm
     - name: Run cluster example in Readme.md
       run: |
-        pipenv run python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping clumpr -k 3 --median --nsplits 4 --support
+        pipenv run python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk --mapping examples/heliconius_mapping.mapping -k 3 --median --nsplits 4 --support
     - name: Run draw examples for empress wrapper
       run: |
         pipenv run python -m draw.draw_empress_wrapper

--- a/Readme.md
+++ b/Readme.md
@@ -19,9 +19,14 @@ Every time you restart the terminal, make sure you run `pipenv shell` before run
 
 ## Running eMPRess
 
+To see help, run:
+```bash
+python empress_cli.py --help
+```
+
 On the command line, the structure of the inputs are:    
 ```bash
-python empress_cli.py <functionality> --host hostfile --parasite parasitefile --mapping mappingfile 
+python empress_cli.py <command> --host hostfile --parasite parasitefile --mapping mappingfile 
 ```
 
 For example, to run Costscape with default parameters, you run:

--- a/Readme.md
+++ b/Readme.md
@@ -20,10 +20,14 @@ Every time you restart the terminal, make sure you run `pipenv shell` before run
 ## Running eMPRess
 
 On the command line, the structure of the inputs are:    
-* `python empress_cli.py -fn <path to tree data file> <functionality>`
+```bash
+python empress_cli.py --host hostfile --parasite parasitefile --mapping mappingfile <functionality>
+```
 
 For example, to run Costscape with default parameters, you run:
-* `python empress_cli.py -fn examples/heliconius.newick costscape`
+```bash
+python empress_cli.py --host hostfile --parasite parasitefile --mapping mappingfile costscape
+```
 
 For specific parameters of each functionality, consult the list below:
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,12 +26,12 @@ python empress_cli.py --help
 
 On the command line, the structure of the inputs are:    
 ```bash
-python empress_cli.py <command> --host hostfile --parasite parasitefile --mapping mappingfile 
+python empress_cli.py <command> hostfile parasitefile mappingfile 
 ```
 
 For example, to run Costscape with default parameters, you run:
 ```bash
-python empress_cli.py cost_regions --host hostfile --parasite parasitefile --mapping mappingfile 
+python empress_cli.py cost_regions hostfile parasitefile mappingfile 
 ```
 
 For specific parameters of each functionality, consult the list below:
@@ -51,8 +51,8 @@ Note: value in parenthesis denotes default value, asterisk denotes boolean flags
 For example, the following example runs Costscape with duplication low value of 0.5, duplication high value of 10, transfer low value of 0.5, 
 and transfer high value of 10, that saves to a file called `foo.pdf` display it in log scale.
 ```bash
-$ python empress_cli.py cost_regions --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                                     --mapping examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 \
+$ python empress_cli.py cost_regions examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
+                                     examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 \
                                      --outfile costscape-example-img.pdf --log
 ```
 
@@ -63,8 +63,8 @@ $ python empress_cli.py cost_regions --host examples/heliconius_host.nwk --paras
 
 For example, to run DTL Reconciliation with duplication cost of 4, transfer cost of 2 and lost cost of 0, you run
 ```bash
-$ python empress_cli.py reconcile --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                                  --mapping examples/heliconius_mapping.mapping -d 4 -t 2 -l 0
+$ python empress_cli.py reconcile examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
+                                  examples/heliconius_mapping.mapping -d 4 -t 2 -l 0
 ```
 
 ### Pair distance Histogram
@@ -82,8 +82,8 @@ $ python empress_cli.py reconcile --host examples/heliconius_host.nwk --parasite
 
 For example, to run Pair-distance Histogram that outputs a csv file at `foo.csv`, outputs a histogram to `bar.pdf` and normalizes the y-axis, you run
 ```bash
-$ python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                                  --mapping examples/heliconius_mapping.mapping -csv foo.csv --histogram bar.pdf --ynorm
+$ python empress_cli.py histogram examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
+                                  examples/heliconius_mapping.mapping -csv foo.csv --histogram bar.pdf --ynorm
 ```
 
 ### Cluster MPR
@@ -101,6 +101,6 @@ $ python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite
 
 For example, to find at least 8 distinct parts of reconciliation-space before merging them into clusters, use `--nsplits 8`. To merge those splits into three clusters, use `-k 3`. The clusters are merged based on a cluster-distance that is calculated either using the average event support or the pairwise distance. To use the event support use `--support`. Finally, to get the median reconciliation of each of the three clusters, use `--median`. Putting it all together, the full command is
 ```bash
-$ python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                                --mapping examples/heliconius_mapping.mapping clumpr -n 3 --median --n-splits 8 --support
+$ python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
+                                examples/heliconius_mapping.mapping clumpr -n 3 --median --n-splits 8 --support
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -102,5 +102,5 @@ $ python empress_cli.py histogram examples/heliconius_host.nwk examples/heliconi
 For example, to find at least 8 distinct parts of reconciliation-space before merging them into clusters, use `--nsplits 8`. To merge those splits into three clusters, use `-k 3`. The clusters are merged based on a cluster-distance that is calculated either using the average event support or the pairwise distance. To use the event support use `--support`. Finally, to get the median reconciliation of each of the three clusters, use `--median`. Putting it all together, the full command is
 ```bash
 $ python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
-                                examples/heliconius_mapping.mapping clumpr -n 3 --median --n-splits 8 --support
+                                examples/heliconius_mapping.mapping clumpr 3 --median --n-splits 8 --support
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -102,5 +102,5 @@ $ python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite
 For example, to find at least 8 distinct parts of reconciliation-space before merging them into clusters, use `--nsplits 8`. To merge those splits into three clusters, use `-k 3`. The clusters are merged based on a cluster-distance that is calculated either using the average event support or the pairwise distance. To use the event support use `--support`. Finally, to get the median reconciliation of each of the three clusters, use `--median`. Putting it all together, the full command is
 ```bash
 $ python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                                --mapping examples/heliconius_mapping.mapping clumpr -k 3 --median --nsplits 8 --support
+                                --mapping examples/heliconius_mapping.mapping clumpr -n 3 --median --n-splits 8 --support
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -21,12 +21,12 @@ Every time you restart the terminal, make sure you run `pipenv shell` before run
 
 On the command line, the structure of the inputs are:    
 ```bash
-python empress_cli.py --host hostfile --parasite parasitefile --mapping mappingfile <functionality>
+python empress_cli.py <functionality> --host hostfile --parasite parasitefile --mapping mappingfile 
 ```
 
 For example, to run Costscape with default parameters, you run:
 ```bash
-python empress_cli.py --host hostfile --parasite parasitefile --mapping mappingfile costscape
+python empress_cli.py cost_regions --host hostfile --parasite parasitefile --mapping mappingfile 
 ```
 
 For specific parameters of each functionality, consult the list below:
@@ -46,9 +46,9 @@ Note: value in parenthesis denotes default value, asterisk denotes boolean flags
 For example, the following example runs Costscape with duplication low value of 0.5, duplication high value of 10, transfer low value of 0.5, 
 and transfer high value of 10, that saves to a file called `foo.pdf` display it in log scale.
 ```bash
-$ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                        --mapping examples/heliconius_mapping.mapping \
-                        costscape -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
+$ python empress_cli.py cost_regions --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
+                                     --mapping examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 \
+                                     --outfile costscape-example-img.pdf --log
 ```
 
 ### DTL Reconciliation
@@ -58,9 +58,8 @@ $ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/
 
 For example, to run DTL Reconciliation with duplication cost of 4, transfer cost of 2 and lost cost of 0, you run
 ```bash
-$ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                        --mapping examples/heliconius_mapping.mapping \
-                        reconcile -d 4 -t 2 -l 0
+$ python empress_cli.py reconcile --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
+                                  --mapping examples/heliconius_mapping.mapping -d 4 -t 2 -l 0
 ```
 
 ### Pair distance Histogram
@@ -78,9 +77,8 @@ $ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/
 
 For example, to run Pair-distance Histogram that outputs a csv file at `foo.csv`, outputs a histogram to `bar.pdf` and normalizes the y-axis, you run
 ```bash
-$ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                        --mapping examples/heliconius_mapping.mapping \
-                        histogram --csv foo.csv --histogram bar.pdf --ynorm
+$ python empress_cli.py histogram --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
+                                  --mapping examples/heliconius_mapping.mapping -csv foo.csv --histogram bar.pdf --ynorm
 ```
 
 ### Cluster MPR
@@ -98,7 +96,6 @@ $ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/
 
 For example, to find at least 8 distinct parts of reconciliation-space before merging them into clusters, use `--nsplits 8`. To merge those splits into three clusters, use `-k 3`. The clusters are merged based on a cluster-distance that is calculated either using the average event support or the pairwise distance. To use the event support use `--support`. Finally, to get the median reconciliation of each of the three clusters, use `--median`. Putting it all together, the full command is
 ```bash
-$ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
-                        --mapping examples/heliconius_mapping.mapping \
-                        clumpr -k 3 --median --nsplits 8 --support
+$ python empress_cli.py cluster --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
+                                --mapping examples/heliconius_mapping.mapping clumpr -k 3 --median --nsplits 8 --support
 ```

--- a/cli_commands/_shared_utils.py
+++ b/cli_commands/_shared_utils.py
@@ -1,16 +1,17 @@
-def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
-    # Read input files
-    cost_regions_parser.add_argument("--host", metavar="<host_file>", required=True,
-                                     help="The path to the host tree file.")
-    cost_regions_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
-                                     help="The path to the parasite tree file.")
-    cost_regions_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
-                                     help="The path to the tip mapping file.")
+import argparse
 
-    # Read duplication/transfer/loss information
-    cluster_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
-                                default=2, help="Duplication cost")
-    cluster_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
-                                default=3, help="Transfer cost")
-    cluster_parser.add_argument("-l", type=float, metavar="<loss_cost>",
-                                default=1, help="Loss cost")
+def add_recon_input_args_to_parser(parser: argparse.ArgumentParser):
+    parser.add_argument("--host", metavar="<host_file>", required=True,
+                        help="file path to the host tree")
+    parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+                        help="file path to the parasite tree")
+    parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+                        help="file path to the tip mapping")
+
+def add_dtl_costs_to_parser(parser: argparse.ArgumentParser):
+    parser.add_argument("-d", "--duplication-cost", type=float, metavar="<duplication_cost>",
+                        required=True, default=2, help="cost incurred on each duplication event")
+    parser.add_argument("-t", "--transfer-cost", type=float, metavar="<transfer_cost>",
+                        required=True, default=3, help="cost incurred on  each transfer event")
+    parser.add_argument("-l", "--loss-cost", type=float, metavar="<loss_cost>",
+                        required=True, default=1, help="cost incurred on each loss event")

--- a/cli_commands/_shared_utils.py
+++ b/cli_commands/_shared_utils.py
@@ -9,9 +9,9 @@ def add_recon_input_args_to_parser(parser: argparse.ArgumentParser):
                         help="file path to the tip mapping")
 
 def add_dtl_costs_to_parser(parser: argparse.ArgumentParser):
-    parser.add_argument("-d", "--duplication-cost", type=float, metavar="<duplication_cost>",
-                        required=True, default=2, help="cost incurred on each duplication event")
-    parser.add_argument("-t", "--transfer-cost", type=float, metavar="<transfer_cost>",
-                        required=True, default=3, help="cost incurred on  each transfer event")
+    parser.add_argument("-d", "--dup-cost", type=float, metavar="<duplication_cost>",
+                        default=2, help="cost incurred on each duplication event")
+    parser.add_argument("-t", "--trans-cost", type=float, metavar="<transfer_cost>",
+                        default=3, help="cost incurred on  each transfer event")
     parser.add_argument("-l", "--loss-cost", type=float, metavar="<loss_cost>",
-                        required=True, default=1, help="cost incurred on each loss event")
+                        default=1, help="cost incurred on each loss event")

--- a/cli_commands/_shared_utils.py
+++ b/cli_commands/_shared_utils.py
@@ -1,11 +1,11 @@
 import argparse
 
 def add_recon_input_args_to_parser(parser: argparse.ArgumentParser):
-    parser.add_argument("--host", metavar="<host_file>", required=True,
+    parser.add_argument("host", metavar="<host_file>",
                         help="file path to the host tree")
-    parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+    parser.add_argument("parasite", metavar="<parasite_file>",
                         help="file path to the parasite tree")
-    parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+    parser.add_argument("mapping", metavar="<mapping_file>",
                         help="file path to the tip mapping")
 
 def add_dtl_costs_to_parser(parser: argparse.ArgumentParser):

--- a/cli_commands/_shared_utils.py
+++ b/cli_commands/_shared_utils.py
@@ -1,0 +1,16 @@
+def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
+    # Read input files
+    cost_regions_parser.add_argument("--host", metavar="<host_file>", required=True,
+                                     help="The path to the host tree file.")
+    cost_regions_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+                                     help="The path to the parasite tree file.")
+    cost_regions_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+                                     help="The path to the tip mapping file.")
+
+    # Read duplication/transfer/loss information
+    cluster_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
+                                default=2, help="Duplication cost")
+    cluster_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
+                                default=3, help="Transfer cost")
+    cluster_parser.add_argument("-l", type=float, metavar="<loss_cost>",
+                                default=1, help="Loss cost")

--- a/cli_commands/cluster.py
+++ b/cli_commands/cluster.py
@@ -1,0 +1,52 @@
+import argparse
+import empress
+from empress.cluster import cluster_main
+
+
+def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
+    # Read input files
+    cluster_parser.add_argument("--host", metavar="<host_file>", required=True,
+                                help="The path to the file with the input host tree.")
+    cluster_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+                                help="The path to the file with the input parasite tree.")
+    cluster_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+                                help="The path to the file with the tip mapping.")
+
+    # Read duplication/transfer/loss information
+    cluster_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
+                                default=2, help="Duplication cost")
+    cluster_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
+                                default=3, help="Transfer cost")
+    cluster_parser.add_argument("-l", type=float, metavar="<loss_cost>",
+                                default=1, help="Loss cost")
+
+    cluster_parser.add_argument("-k", type=int, metavar="<number_of_clusters>", help="Number of clusters")
+
+    cluster_parser.add_argument("--medians", action="store_true", required=False,
+                                help="Whether or not to print out medians for each cluster")
+
+    # Specifies how far down to go when finding splits
+    depth_or_n = cluster_parser.add_mutually_exclusive_group(required=True)
+    depth_or_n.add_argument("--depth", type=int, metavar="<tree_depth>",
+                            help="How far down to split the graph before clustering")
+    depth_or_n.add_argument("--nsplits", type=int, metavar="<tree_depth>",
+                            help="Find at least n splits before combining the splits into clusters")
+
+    # What visualizations to produce
+    vis_type = cluster_parser.add_mutually_exclusive_group(required=False)
+    vis_type.add_argument("--pdv-vis", action="store_true",
+                          help="Visualize the resulting clusters using the Pairwise Distance")
+    vis_type.add_argument("--support-vis", action="store_true",
+                          help="Visualize the resulting clusters using event supports")
+
+    # Which objective function to use
+    score = cluster_parser.add_mutually_exclusive_group(required=True)
+    score.add_argument("--pdv", action="store_true",
+                       help="Use the weighted average distance to evaluate clusters")
+    score.add_argument("--support", action="store_true",
+                       help="Use the weighted average event support to evaluate clusters")
+
+
+def run_cost_regions(args):
+    recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
+    cluster_main.perform_clustering(recon_input, args.d, args.t, args.l, args.k, args)

--- a/cli_commands/cluster.py
+++ b/cli_commands/cluster.py
@@ -1,50 +1,38 @@
 import argparse
 import empress
 from empress.cluster import cluster_main
+import cli_commands._shared_utils
 
 
 def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
-    # Read input files
-    cluster_parser.add_argument("--host", metavar="<host_file>", required=True,
-                                help="The path to the file with the input host tree.")
-    cluster_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
-                                help="The path to the file with the input parasite tree.")
-    cluster_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
-                                help="The path to the file with the tip mapping.")
-
-    # Read duplication/transfer/loss information
-    cluster_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
-                                default=2, help="Duplication cost")
-    cluster_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
-                                default=3, help="Transfer cost")
-    cluster_parser.add_argument("-l", type=float, metavar="<loss_cost>",
-                                default=1, help="Loss cost")
+    cli_commands._shared_utils.add_recon_input_args_to_parser(cluster_parser)
+    cli_commands._shared_utils.add_dtl_costs_to_parser(cluster_parser)
 
     cluster_parser.add_argument("-k", type=int, metavar="<number_of_clusters>", help="Number of clusters")
 
     cluster_parser.add_argument("--medians", action="store_true", required=False,
-                                help="Whether or not to print out medians for each cluster")
+                                help="whether or not to print out medians for each cluster")
 
     # Specifies how far down to go when finding splits
     depth_or_n = cluster_parser.add_mutually_exclusive_group(required=True)
     depth_or_n.add_argument("--depth", type=int, metavar="<tree_depth>",
-                            help="How far down to split the graph before clustering")
+                            help="how far down to split the graph before clustering")
     depth_or_n.add_argument("--nsplits", type=int, metavar="<tree_depth>",
-                            help="Find at least n splits before combining the splits into clusters")
+                            help="find at least n splits before combining the splits into clusters")
 
     # What visualizations to produce
     vis_type = cluster_parser.add_mutually_exclusive_group(required=False)
     vis_type.add_argument("--pdv-vis", action="store_true",
-                          help="Visualize the resulting clusters using the Pairwise Distance")
+                          help="visualize the resulting clusters using the Pairwise Distance")
     vis_type.add_argument("--support-vis", action="store_true",
-                          help="Visualize the resulting clusters using event supports")
+                          help="visualize the resulting clusters using event supports")
 
     # Which objective function to use
     score = cluster_parser.add_mutually_exclusive_group(required=True)
     score.add_argument("--pdv", action="store_true",
-                       help="Use the weighted average distance to evaluate clusters")
+                       help="use the weighted average distance to evaluate clusters")
     score.add_argument("--support", action="store_true",
-                       help="Use the weighted average event support to evaluate clusters")
+                       help="use the weighted average event support to evaluate clusters")
 
 
 def run_cost_regions(args):

--- a/cli_commands/cluster.py
+++ b/cli_commands/cluster.py
@@ -6,9 +6,9 @@ import cli_commands._shared_utils
 
 def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
     cli_commands._shared_utils.add_recon_input_args_to_parser(cluster_parser)
-    cluster_parser.add_argument("n_clusters", type=int, metavar="<number_of_clusters>", help="Number of clusters")
-
     cli_commands._shared_utils.add_dtl_costs_to_parser(cluster_parser)
+
+    cluster_parser.add_argument("n_clusters", type=int, metavar="<number_of_clusters>", help="Number of clusters")
 
     cluster_parser.add_argument("--medians", action="store_true", required=False,
                                 help="whether or not to print out medians for each cluster")

--- a/cli_commands/cluster.py
+++ b/cli_commands/cluster.py
@@ -8,7 +8,7 @@ def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
     cli_commands._shared_utils.add_recon_input_args_to_parser(cluster_parser)
     cli_commands._shared_utils.add_dtl_costs_to_parser(cluster_parser)
 
-    cluster_parser.add_argument("-k", type=int, metavar="<number_of_clusters>", help="Number of clusters")
+    cluster_parser.add_argument("-n", "--n-clusters", type=int, metavar="<number_of_clusters>", help="Number of clusters")
 
     cluster_parser.add_argument("--medians", action="store_true", required=False,
                                 help="whether or not to print out medians for each cluster")
@@ -17,7 +17,7 @@ def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
     depth_or_n = cluster_parser.add_mutually_exclusive_group(required=True)
     depth_or_n.add_argument("--depth", type=int, metavar="<tree_depth>",
                             help="how far down to split the graph before clustering")
-    depth_or_n.add_argument("--nsplits", type=int, metavar="<tree_depth>",
+    depth_or_n.add_argument("--n-splits", type=int, metavar="<tree_depth>",
                             help="find at least n splits before combining the splits into clusters")
 
     # What visualizations to produce
@@ -35,6 +35,6 @@ def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
                        help="use the weighted average event support to evaluate clusters")
 
 
-def run_cost_regions(args):
+def run_cluster(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
-    cluster_main.perform_clustering(recon_input, args.d, args.t, args.l, args.k, args)
+    cluster_main.perform_clustering(recon_input, args.dup_cost, args.trans_cost, args.loss_cost, args.n_clusters, args)

--- a/cli_commands/cluster.py
+++ b/cli_commands/cluster.py
@@ -6,9 +6,9 @@ import cli_commands._shared_utils
 
 def add_cluster_to_parser(cluster_parser: argparse.ArgumentParser):
     cli_commands._shared_utils.add_recon_input_args_to_parser(cluster_parser)
-    cli_commands._shared_utils.add_dtl_costs_to_parser(cluster_parser)
+    cluster_parser.add_argument("n_clusters", type=int, metavar="<number_of_clusters>", help="Number of clusters")
 
-    cluster_parser.add_argument("-n", "--n-clusters", type=int, metavar="<number_of_clusters>", help="Number of clusters")
+    cli_commands._shared_utils.add_dtl_costs_to_parser(cluster_parser)
 
     cluster_parser.add_argument("--medians", action="store_true", required=False,
                                 help="whether or not to print out medians for each cluster")

--- a/cli_commands/cost_regions.py
+++ b/cli_commands/cost_regions.py
@@ -1,32 +1,27 @@
 import argparse
+
 import empress
 from empress.xscape import costscape
-
+import cli_commands._shared_utils
 
 def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
-    # Read input files
-    cost_regions_parser.add_argument("--host", metavar="<host_file>", required=True,
-                                     help="The path to the host tree file.")
-    cost_regions_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
-                                     help="The path to the parasite tree file.")
-    cost_regions_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
-                                     help="The path to the tip mapping file.")
+    cli_commands._shared_utils.add_recon_input_args_to_parser(cost_regions_parser)
 
     # Read cost_regions information
     cost_regions_parser.add_argument("-dl", "--duplication_low", metavar="<duplication_low>", default=1,
-                                     type=float, help="Duplication low value for cost regions viewer window")
+                                     type=float, help="duplication low value for cost regions viewer window")
     cost_regions_parser.add_argument("-dh", "--duplication_high", metavar="<duplication_high>", default=5,
-                                     type=float, help="Duplication high value for cost regions viewer window")
+                                     type=float, help="duplication high value for cost regions viewer window")
     cost_regions_parser.add_argument("-tl", "--transfer_low", metavar="<transfer_low>", default=1,
-                                     type=float, help="Transfer low value for cost regions viewer window")
+                                     type=float, help="transfer low value for cost regions viewer window")
     cost_regions_parser.add_argument("-th", "--transfer_high", metavar="<transfer_high>", default=5,
-                                     type=float, help="Transfer high value for cost regions viewer window")
+                                     type=float, help="transfer high value for cost regions viewer window")
     cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default="",
-                                     help="Name of output file, ending in .pdf")
+                                     help="name of output file, ending with .pdf")
     cost_regions_parser.add_argument("--log", action="store_true",
-                                     help="Set display to log scale")
+                                     help="set display to log scale")
     cost_regions_parser.add_argument("--display", action="store_true",
-                                     help="Display output on screen")
+                                     help="display output on screen")
 
 
 def run_cost_regions(args):

--- a/cli_commands/cost_regions.py
+++ b/cli_commands/cost_regions.py
@@ -1,0 +1,35 @@
+import argparse
+import empress
+from empress.xscape import costscape
+
+
+def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
+    # Read input files
+    cost_regions_parser.add_argument("--host", metavar="<host_file>", required=True,
+                                     help="The path to the host tree file.")
+    cost_regions_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+                                     help="The path to the parasite tree file.")
+    cost_regions_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+                                     help="The path to the tip mapping file.")
+
+    # Read cost_regions information
+    cost_regions_parser.add_argument("-dl", "--duplication_low", metavar="<duplication_low>", default=1,
+                                     type=float, help="Duplication low value for cost regions viewer window")
+    cost_regions_parser.add_argument("-dh", "--duplication_high", metavar="<duplication_high>", default=5,
+                                     type=float, help="Duplication high value for cost regions viewer window")
+    cost_regions_parser.add_argument("-tl", "--transfer_low", metavar="<transfer_low>", default=1,
+                                     type=float, help="Transfer low value for cost regions viewer window")
+    cost_regions_parser.add_argument("-th", "--transfer_high", metavar="<transfer_high>", default=5,
+                                     type=float, help="Transfer high value for cost regions viewer window")
+    cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default="",
+                                     help="Name of output file, ending in .pdf")
+    cost_regions_parser.add_argument("--log", action="store_true",
+                                     help="Set display to log scale")
+    cost_regions_parser.add_argument("--display", action="store_true",
+                                     help="Display output on screen")
+
+
+def run_cost_regions(args):
+    recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
+    costscape.solve(recon_input, args.duplication_low, args.duplication_high, args.transfer_low, args.transfer_high,
+                    args)

--- a/cli_commands/cost_regions.py
+++ b/cli_commands/cost_regions.py
@@ -8,13 +8,13 @@ def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
     cli_commands._shared_utils.add_recon_input_args_to_parser(cost_regions_parser)
 
     # Read cost_regions information
-    cost_regions_parser.add_argument("-dl", "--duplication_low", metavar="<duplication_low>", default=1,
+    cost_regions_parser.add_argument("-dl", "--duplication-low", metavar="<duplication_low>", default=1,
                                      type=float, help="duplication low value for cost regions viewer window")
-    cost_regions_parser.add_argument("-dh", "--duplication_high", metavar="<duplication_high>", default=5,
+    cost_regions_parser.add_argument("-dh", "--duplication-high", metavar="<duplication_high>", default=5,
                                      type=float, help="duplication high value for cost regions viewer window")
-    cost_regions_parser.add_argument("-tl", "--transfer_low", metavar="<transfer_low>", default=1,
+    cost_regions_parser.add_argument("-tl", "--transfer-low", metavar="<transfer_low>", default=1,
                                      type=float, help="transfer low value for cost regions viewer window")
-    cost_regions_parser.add_argument("-th", "--transfer_high", metavar="<transfer_high>", default=5,
+    cost_regions_parser.add_argument("-th", "--transfer-high", metavar="<transfer_high>", default=5,
                                      type=float, help="transfer high value for cost regions viewer window")
     cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default="",
                                      help="name of output file, ending with .pdf")

--- a/cli_commands/histogram.py
+++ b/cli_commands/histogram.py
@@ -36,10 +36,10 @@ def add_histogram_to_parser(histogram_parser: argparse.ArgumentParser):
                                   help="time the diameter algorithm")
 
 
-def run_cost_regions(args):
+def run_histogram(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
     fname = Path(args.host)
-    cost_suffix = ".{}-{}-{}".format(args.d, args.t, args.l)
+    cost_suffix = ".{}-{}-{}".format(args.dup_cost, args.trans_cost, args.loss_cost)
     # If args is unset, use the original .newick file path but replace .newick with .pdf
     if args.histogram is None:
         args.histogram = str(fname.with_suffix(cost_suffix + ".pdf"))
@@ -57,4 +57,4 @@ def run_cost_regions(args):
         c = Path(args.csv)
         assert c.suffix == ".csv"
 
-    histogram_main.compute_pdv(args.host, recon_input, args.d, args.t, args.l, args)
+    histogram_main.compute_pdv(args.host, recon_input, args.dup_cost, args.trans_cost, args.loss_cost, args)

--- a/cli_commands/histogram.py
+++ b/cli_commands/histogram.py
@@ -1,0 +1,70 @@
+import argparse
+from pathlib import Path
+
+import empress
+from empress.histogram import histogram_main
+
+
+def add_histogram_to_parser(histogram_parser: argparse.ArgumentParser):
+    # Read input files
+    histogram_parser.add_argument("--host", metavar="<host_file>", required=True,
+                                     help="The path to the host tree file.")
+    histogram_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+                                     help="The path to the parasite tree file.")
+    histogram_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+                                     help="The path to the tip mapping file.")
+
+    # Read duplication/transfer/loss information
+    histogram_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
+                                  default=2, help="Duplication cost")
+    histogram_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
+                                  default=3, help="Transfer cost")
+    histogram_parser.add_argument("-l", type=float, metavar="<loss_cost>",
+                                  default=1, help="Loss cost")
+
+    histogram_parser.add_argument("--histogram", metavar="<filename>", default="unset",
+                                  nargs="?", help="Output the histogram at the path provided. \
+            If no filename is provided, outputs to a filename based on the input .newick file.")
+    histogram_parser.add_argument("--xnorm", action="store_true",
+                                  help="Normalize the x-axis so that the distances range between 0 and 1.")
+    histogram_parser.add_argument("--ynorm", action="store_true",
+                                  help="Normalize the y-axis so that the histogram is a probability distribution.")
+    histogram_parser.add_argument("--omit_zeros", action="store_true",
+                                  help="Omit the zero column of the histogram, which will always be the total number of reconciliations.")
+    histogram_parser.add_argument("--cumulative", action="store_true",
+                                  help="Make the histogram cumulative.")
+    histogram_parser.add_argument("--csv", metavar="<filename>", default="unset", nargs="?",
+                                  help="Output the histogram as a .csv file at the path provided. \
+            If no filename is provided, outputs to a filename based on the input .newick file.")
+
+    # Statistics to print
+    histogram_parser.add_argument("--stats", action="store_true",
+                                  help="Output statistics including the total number of MPRs, the diameter of MPR-space, and the average distance between MPRs.")
+
+    # Time it
+    histogram_parser.add_argument("--time", action="store_true",
+                                  help="Time the diameter algorithm")
+
+
+def run_cost_regions(args):
+    recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
+    fname = Path(args.host)
+    cost_suffix = ".{}-{}-{}".format(args.d, args.t, args.l)
+    # If args is unset, use the original .newick file path but replace .newick with .pdf
+    if args.histogram is None:
+        args.histogram = str(fname.with_suffix(cost_suffix + ".pdf"))
+    # If it wasn't set by the arg parser, then set it to None (the option wasn't present)
+    elif args.histogram == "unset":
+        args.histogram = None
+    # TODO: check that the specified path has a matplotlib-compatible extension?
+    # Do the same for .csv
+    if args.csv is None:
+        args.csv = str(fname.with_suffix(cost_suffix + ".csv"))
+    elif args.csv == "unset":
+        args.csv = None
+    # If it was user-specified, check that it has a .csv extension
+    else:
+        c = Path(args.csv)
+        assert c.suffix == ".csv"
+
+    histogram_main.compute_pdv(args.host, recon_input, args.d, args.t, args.l, args)

--- a/cli_commands/histogram.py
+++ b/cli_commands/histogram.py
@@ -3,49 +3,37 @@ from pathlib import Path
 
 import empress
 from empress.histogram import histogram_main
+import cli_commands._shared_utils
 
 
 def add_histogram_to_parser(histogram_parser: argparse.ArgumentParser):
-    # Read input files
-    histogram_parser.add_argument("--host", metavar="<host_file>", required=True,
-                                     help="The path to the host tree file.")
-    histogram_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
-                                     help="The path to the parasite tree file.")
-    histogram_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
-                                     help="The path to the tip mapping file.")
-
-    # Read duplication/transfer/loss information
-    histogram_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
-                                  default=2, help="Duplication cost")
-    histogram_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
-                                  default=3, help="Transfer cost")
-    histogram_parser.add_argument("-l", type=float, metavar="<loss_cost>",
-                                  default=1, help="Loss cost")
+    cli_commands._shared_utils.add_recon_input_args_to_parser(histogram_parser)
+    cli_commands._shared_utils.add_dtl_costs_to_parser(histogram_parser)
 
     histogram_parser.add_argument("--histogram", metavar="<filename>", default="unset",
-                                  nargs="?", help="Output the histogram at the path provided. If no filename is "
-                                                  "provided, outputs to a filename based on the input host file.")
+                                  nargs="?", help="output the histogram at the path provided. If no filename is "
+                                                  "provided, outputs to a filename based on the input host file")
     histogram_parser.add_argument("--xnorm", action="store_true",
-                                  help="Normalize the x-axis so that the distances range between 0 and 1.")
+                                  help="normalize the x-axis so that the distances range between 0 and 1")
     histogram_parser.add_argument("--ynorm", action="store_true",
-                                  help="Normalize the y-axis so that the histogram is a probability distribution.")
+                                  help="normalize the y-axis so that the histogram is a probability distribution")
     histogram_parser.add_argument("--omit_zeros", action="store_true",
-                                  help="Omit the zero column of the histogram, which will always be the total number "
-                                       "of reconciliations.")
+                                  help="omit the zero column of the histogram, which will always be the total number "
+                                       "of reconciliations")
     histogram_parser.add_argument("--cumulative", action="store_true",
-                                  help="Make the histogram cumulative.")
+                                  help="make the histogram cumulative")
     histogram_parser.add_argument("--csv", metavar="<filename>", default="unset", nargs="?",
-                                  help="Output the histogram as a .csv file at the path provided. If no filename is "
-                                       "provided, outputs to a filename based on the input host file.")
+                                  help="output the histogram as a .csv file at the path provided. If no filename is "
+                                       "provided, outputs to a filename based on the input host file")
 
     # Statistics to print
     histogram_parser.add_argument("--stats", action="store_true",
-                                  help="Output statistics including the total number of MPRs, the diameter of "
-                                       "MPR-space, and the average distance between MPRs.")
+                                  help="output statistics including the total number of MPRs, the diameter of "
+                                       "MPR-space, and the average distance between MPRs")
 
     # Time it
     histogram_parser.add_argument("--time", action="store_true",
-                                  help="Time the diameter algorithm")
+                                  help="time the diameter algorithm")
 
 
 def run_cost_regions(args):

--- a/cli_commands/histogram.py
+++ b/cli_commands/histogram.py
@@ -23,23 +23,25 @@ def add_histogram_to_parser(histogram_parser: argparse.ArgumentParser):
                                   default=1, help="Loss cost")
 
     histogram_parser.add_argument("--histogram", metavar="<filename>", default="unset",
-                                  nargs="?", help="Output the histogram at the path provided. \
-            If no filename is provided, outputs to a filename based on the input .newick file.")
+                                  nargs="?", help="Output the histogram at the path provided. If no filename is "
+                                                  "provided, outputs to a filename based on the input host file.")
     histogram_parser.add_argument("--xnorm", action="store_true",
                                   help="Normalize the x-axis so that the distances range between 0 and 1.")
     histogram_parser.add_argument("--ynorm", action="store_true",
                                   help="Normalize the y-axis so that the histogram is a probability distribution.")
     histogram_parser.add_argument("--omit_zeros", action="store_true",
-                                  help="Omit the zero column of the histogram, which will always be the total number of reconciliations.")
+                                  help="Omit the zero column of the histogram, which will always be the total number "
+                                       "of reconciliations.")
     histogram_parser.add_argument("--cumulative", action="store_true",
                                   help="Make the histogram cumulative.")
     histogram_parser.add_argument("--csv", metavar="<filename>", default="unset", nargs="?",
-                                  help="Output the histogram as a .csv file at the path provided. \
-            If no filename is provided, outputs to a filename based on the input .newick file.")
+                                  help="Output the histogram as a .csv file at the path provided. If no filename is "
+                                       "provided, outputs to a filename based on the input host file.")
 
     # Statistics to print
     histogram_parser.add_argument("--stats", action="store_true",
-                                  help="Output statistics including the total number of MPRs, the diameter of MPR-space, and the average distance between MPRs.")
+                                  help="Output statistics including the total number of MPRs, the diameter of "
+                                       "MPR-space, and the average distance between MPRs.")
 
     # Time it
     histogram_parser.add_argument("--time", action="store_true",

--- a/cli_commands/histogram.py
+++ b/cli_commands/histogram.py
@@ -17,7 +17,7 @@ def add_histogram_to_parser(histogram_parser: argparse.ArgumentParser):
                                   help="normalize the x-axis so that the distances range between 0 and 1")
     histogram_parser.add_argument("--ynorm", action="store_true",
                                   help="normalize the y-axis so that the histogram is a probability distribution")
-    histogram_parser.add_argument("--omit_zeros", action="store_true",
+    histogram_parser.add_argument("--omit-zeros", action="store_true",
                                   help="omit the zero column of the histogram, which will always be the total number "
                                        "of reconciliations")
     histogram_parser.add_argument("--cumulative", action="store_true",

--- a/cli_commands/reconcile.py
+++ b/cli_commands/reconcile.py
@@ -9,6 +9,6 @@ def add_reconcile_to_parser(reconcile_parser: argparse.ArgumentParser):
     cli_commands._shared_utils.add_recon_input_args_to_parser(reconcile_parser)
     cli_commands._shared_utils.add_dtl_costs_to_parser(reconcile_parser)
 
-def run_cost_regions(args):
+def run_reconcile(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
-    recongraph_tools.reconcile_noninter(recon_input, args.d, args.t, args.l)
+    recongraph_tools.reconcile_noninter(recon_input, args.dup_cost, args.trans_cost, args.loss_cost)

--- a/cli_commands/reconcile.py
+++ b/cli_commands/reconcile.py
@@ -1,0 +1,26 @@
+import argparse
+import empress
+from empress.reconcile import recongraph_tools
+
+
+def add_reconcile_to_parser(reconcile_parser: argparse.ArgumentParser):
+    # Read input files
+    reconcile_parser.add_argument("--host", metavar="<host_file>", required=True,
+                                  help="The path to the host tree file.")
+    reconcile_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
+                                  help="The path to the parasite tree file.")
+    reconcile_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
+                                  help="The path to the tip mapping file.")
+
+    # Read dtl costs
+    reconcile_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
+                                  default=2, help="Duplication cost")
+    reconcile_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
+                                  default=3, help="Transfer cost")
+    reconcile_parser.add_argument("-l", type=float, metavar="<loss_cost>",
+                                  default=1, help="Loss cost")
+
+
+def run_cost_regions(args):
+    recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
+    recongraph_tools.reconcile_noninter(recon_input, args.d, args.t, args.l)

--- a/cli_commands/reconcile.py
+++ b/cli_commands/reconcile.py
@@ -1,25 +1,13 @@
 import argparse
+
 import empress
 from empress.reconcile import recongraph_tools
+import cli_commands._shared_utils
 
 
 def add_reconcile_to_parser(reconcile_parser: argparse.ArgumentParser):
-    # Read input files
-    reconcile_parser.add_argument("--host", metavar="<host_file>", required=True,
-                                  help="The path to the host tree file.")
-    reconcile_parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
-                                  help="The path to the parasite tree file.")
-    reconcile_parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
-                                  help="The path to the tip mapping file.")
-
-    # Read dtl costs
-    reconcile_parser.add_argument("-d", type=float, metavar="<duplication_cost>",
-                                  default=2, help="Duplication cost")
-    reconcile_parser.add_argument("-t", type=float, metavar="<transfer_cost>",
-                                  default=3, help="Transfer cost")
-    reconcile_parser.add_argument("-l", type=float, metavar="<loss_cost>",
-                                  default=1, help="Loss cost")
-
+    cli_commands._shared_utils.add_recon_input_args_to_parser(reconcile_parser)
+    cli_commands._shared_utils.add_dtl_costs_to_parser(reconcile_parser)
 
 def run_cost_regions(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)

--- a/empress/cluster/cluster_main.py
+++ b/empress/cluster/cluster_main.py
@@ -52,17 +52,17 @@ def vis(species_tree, gene_tree, gene_root, recon_g, cluster_gs, args, mk_get_hi
     :param tree_data <str>: file location
     """
     get_hist = mk_get_hist(species_tree, gene_tree, gene_root)
-    cost_suffix = ".{}-{}-{}".format(args.d, args.t, args.l)
+    cost_suffix = ".{}-{}-{}".format(args.dup_cost, args.trans_cost, args.loss_cost)
     p = Path(tree_data)
     orig_p = str(p.with_suffix(cost_suffix + ".pdf"))
     orig_h = get_hist(recon_g)
     max_x, max_y = get_max(orig_h)
-    plot_f(orig_p, orig_h, 1, Path(tree_data).stem, args.d, args.t, args.l, max_x, max_y, False)
+    plot_f(orig_p, orig_h, 1, Path(tree_data).stem, args.dup_cost, args.trans_cost, args.loss_cost, max_x, max_y, False)
     for i, g in enumerate(cluster_gs):
-        g_i = "-{}cluster{}".format(args.k, i)
+        g_i = "-{}cluster{}".format(args.n_clusters, i)
         g_p = str(p.with_suffix("." + g_i + cost_suffix + ".pdf"))
         g_h = get_hist(g)
-        plot_f(g_p, g_h, 1, Path(tree_data).stem + g_i, args.d, args.t, args.l, max_x, max_y, False)
+        plot_f(g_p, g_h, 1, Path(tree_data).stem + g_i, args.dup_cost, args.trans_cost, args.loss_cost, max_x, max_y, False)
 
 def support_vis(species_tree, gene_tree, gene_root, recon_g, cluster_gs, args, tree_data):
     """

--- a/empress/cluster/cluster_main.py
+++ b/empress/cluster/cluster_main.py
@@ -158,9 +158,9 @@ def perform_clustering(tree_data, d, t, l, k, args):
     score = mk_score(species_tree, gene_tree, gene_root)
     # Actually perform the clustering
     if args.depth is not None:
-        graphs,scores,_ = cluster_util.cluster_graph(recon_g, gene_root, score, args.depth, k, 200)
-    elif args.nsplits is not None:
-        graphs,scores,_ = cluster_util.cluster_graph_n(recon_g, gene_root, score, args.nsplits, mpr_count, k, 200)
+        graphs, scores, _ = cluster_util.cluster_graph(recon_g, gene_root, score, args.depth, k, 200)
+    elif args.n_splits is not None:
+        graphs, scores, _ = cluster_util.cluster_graph_n(recon_g, gene_root, score, args.n_splits, mpr_count, k, 200)
     else:
         assert False
     # Visualization

--- a/empress/histogram/histogram_main.py
+++ b/empress/histogram/histogram_main.py
@@ -113,7 +113,8 @@ def compute_pdv(filename, tree_data, d, t, l, args):
     hist_new, width = transform_hist(hist, args.omit_zeros, args.xnorm, args.ynorm, args.cumulative)
     # Make the histogram image
     if args.histogram is not None:
-        histogram_display.plot_histogram(args.histogram, hist, width, Path(args.host).stem, args.d, args.t, args.l)
+        histogram_display.plot_histogram(args.histogram, hist, width, Path(args.host).stem,
+                                         args.dup_cost, args.trans_cost, args.loss_cost)
     if args.csv is not None:
         histogram_display.csv_histogram(args.csv, hist)
 

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -59,11 +59,11 @@ def main():
     if args.command == "cost_regions":  # argparse automatically converts "-" to "_"
         cli_commands.cost_regions.run_cost_regions(args)
     elif args.command == "reconcile":
-        cli_commands.reconcile.run_cost_regions(args)
+        cli_commands.reconcile.run_reconcile(args)
     elif args.command == "histogram":
-        cli_commands.histogram.run_cost_regions(args)
+        cli_commands.histogram.run_histogram(args)
     elif args.command == "cluster":
-        cli_commands.cluster.run_cost_regions(args)
+        cli_commands.cluster.run_cluster(args)
 
 
 if __name__ == "__main__":

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -11,27 +11,39 @@ import cli_commands.cost_regions
 import cli_commands.histogram
 import cli_commands.reconcile
 
+
 def main():
-    parser = argparse.ArgumentParser("empress tool for duplication-transfer-loss maximum parsimony reconciliation")
+    parser = argparse.ArgumentParser(
+        description="Empress tool for duplication-transfer-loss maximum parsimony reconciliation.",
+        epilog="Show help for each command by running `python empress_cli.py <command> --help`"
+    )
 
     # Create subparsers and setup the subparsers
     subparsers = parser.add_subparsers(dest='command', help='Commands empress can run')
 
-    cost_regions_parser = subparsers.add_parser('cost_regions',
-                                                help="Find cost regions that give the same reconciliations")
+    cost_regions_parser = subparsers.add_parser(
+        'cost_regions', help="Find cost regions that give same maximum parsimony reconciliations"
+    )
     cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
-    reconcile_parser = subparsers.add_parser('reconcile', help="Find the reconciliation graph given the dtl costs")
+    reconcile_parser = subparsers.add_parser(
+        'reconcile', help="Find maximum parsimony reconciliations given duplication, transfer, and loss costs"
+    )
     cli_commands.reconcile.add_reconcile_to_parser(reconcile_parser)
-    histogram_parser = subparsers.add_parser('cluster',
-                                             help="Find pairwise distance histogram of reconciliation space")
+    histogram_parser = subparsers.add_parser(
+        'histogram', help="Find pairwise distance histogram of all reconciliations given duplication, transfer, "
+                          "and loss costs"
+    )
     cli_commands.histogram.add_histogram_to_parser(histogram_parser)
-    cluster_parser = subparsers.add_parser('cluster', help="Find cluster of reconciliations with same properties")
+    cluster_parser = subparsers.add_parser(
+        'cluster', help="Find cluster of reconciliations with similar properties given duplication, transfer, "
+                          "and loss costs"
+    )
     cli_commands.cluster.add_cluster_to_parser(cluster_parser)
 
     # Determine which command we should run and run the correct command
     args = parser.parse_args()
 
-    if args.command == "cost_regions":  # argparse - characters will be converted to _ characters
+    if args.command == "cost_regions":  # argparse automatically converts "-" to "_"
         cli_commands.cost_regions.run_cost_regions(args)
     elif args.command == "reconcile":
         cli_commands.reconcile.run_cost_regions(args)

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -25,7 +25,7 @@ def main():
         'cost_regions',
         description="Find cost regions that give same maximum parsimony reconciliations.",
         help="find cost regions that give same maximum parsimony reconciliations",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # print default value
     )
     cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
 
@@ -33,7 +33,7 @@ def main():
         'reconcile',
         description="Find maximum parsimony reconciliations given duplication, transfer, and loss costs.",
         help="find maximum parsimony reconciliations given duplication, transfer, and loss costs",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.reconcile.add_reconcile_to_parser(reconcile_parser)
 
@@ -41,7 +41,7 @@ def main():
         'histogram',
         description="Find pairwise distance histogram of all reconciliations given duplication, transfer, and loss costs.",
         help="find pairwise distance histogram of all reconciliations given duplication, transfer, and loss costs",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.histogram.add_histogram_to_parser(histogram_parser)
 
@@ -49,7 +49,7 @@ def main():
         'cluster',
         description="Find cluster of reconciliations with similar properties given duplication, transfer, and loss costs.",
         help="find cluster of reconciliations with similar properties given duplication, transfer, and loss costs",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.cluster.add_cluster_to_parser(cluster_parser)
 

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -21,34 +21,32 @@ def main():
     # Create subparsers and setup the subparsers
     subparsers = parser.add_subparsers(dest='command', help='Commands empress can run')
 
+    cost_regions_description = "Find cost regions that give same maximum parsimony reconciliations."
     cost_regions_parser = subparsers.add_parser(
-        'cost_regions',
-        description="Find cost regions that give same maximum parsimony reconciliations.",
-        help="find cost regions that give same maximum parsimony reconciliations",
+        'cost_regions', description=cost_regions_description, help=cost_regions_description.lower().rstrip('.'),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # print default value
     )
     cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
 
+    reconcile_description = "Find maximum parsimony reconciliations given duplication, transfer, and loss costs."
     reconcile_parser = subparsers.add_parser(
-        'reconcile',
-        description="Find maximum parsimony reconciliations given duplication, transfer, and loss costs.",
-        help="find maximum parsimony reconciliations given duplication, transfer, and loss costs",
+        'reconcile', description=reconcile_description, help=reconcile_description.lower().rstrip('.'),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.reconcile.add_reconcile_to_parser(reconcile_parser)
 
+    histogram_description = "Find pairwise distance histogram of all reconciliations given duplication, transfer, " \
+                            "and loss costs."
     histogram_parser = subparsers.add_parser(
-        'histogram',
-        description="Find pairwise distance histogram of all reconciliations given duplication, transfer, and loss costs.",
-        help="find pairwise distance histogram of all reconciliations given duplication, transfer, and loss costs",
+        'histogram', description=histogram_description, help=histogram_description.lower().rstrip('.'),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.histogram.add_histogram_to_parser(histogram_parser)
 
+    cluster_description = "Find cluster of reconciliations with similar properties given duplication, transfer, " \
+                          "and loss costs. "
     cluster_parser = subparsers.add_parser(
-        'cluster',
-        description="Find cluster of reconciliations with similar properties given duplication, transfer, and loss costs.",
-        help="find cluster of reconciliations with similar properties given duplication, transfer, and loss costs",
+        'cluster', description=cluster_description, help=cluster_description.lower().rstrip('.'),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.cluster.add_cluster_to_parser(cluster_parser)

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -1,154 +1,44 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # empress_cli.py
 # Cat Ngo, April 2020
 # Updated 6/1/2020 by RLH
 
 import argparse
-from pathlib import Path
 
-import empress
-from empress.reconcile import recongraph_tools
-from empress.cluster import cluster_main
-from empress.histogram import histogram_main
-from empress.xscape import costscape
-
-def process_arg():
-    """ Returns args parse object that contains all parameters needed to run a functionality
-    :return args - the object that contains all necessary params for the desired functionality to run
-    """
-    parser = argparse.ArgumentParser()
-
-    ### Path to newick file ###
-    parser.add_argument("--host", metavar="<host_file>", required=True,
-                        help="The path to the file with the input host tree.")
-    parser.add_argument("--parasite", metavar="<parasite_file>", required=True,
-                        help="The path to the file with the input parasite tree.")
-    parser.add_argument("--mapping", metavar="<mapping_file>", required=True,
-                        help="The path to the file with the tip mapping.")
-    
-    # subparsers to encode for each functionality 
-    subparsers = parser.add_subparsers(dest='functionality',help='Functions empress can run')
-    
-    ### Parser for costscape ###
-    costscape_parser = subparsers.add_parser('costscape', help="Run costscape")
-    costscape_parser.add_argument("-dl", metavar="<duplication_low>", default = 1, 
-        type=float, help="Duplication low value for costcape")
-    costscape_parser.add_argument("-dh", metavar="<duplication_high>", default = 5, 
-        type=float, help="Duplication high value for costcape")
-    costscape_parser.add_argument("-tl", metavar="<transfer_low>", default = 1, 
-        type=float, help="Transfer low value for costcape")
-    costscape_parser.add_argument("-th", metavar="<transfer_high>", default = 5, 
-        type=float, help="Transfer high value for costcape")
-    costscape_parser.add_argument("--outfile", metavar="<output_file>", default = "",
-        help="Name of output file, ending in .pdf")
-    costscape_parser.add_argument("--log", action= "store_true",
-        help="Set display to log scale")
-    costscape_parser.add_argument("--display", action= "store_true",
-        help="Display output on screen")
-    
-    ### Parser for reconcile ###
-    reconcile_parser = subparsers.add_parser('reconcile', help="Run reconcile")
-    reconcile_parser.add_argument("-d", type=float, metavar="<duplication_cost>", 
-        default = 2, help="Duplication cost")
-    reconcile_parser.add_argument("-t", type=float, metavar="<transfer_cost>", 
-        default = 3, help="Transfer cost")
-    reconcile_parser.add_argument("-l", type=float, metavar="<loss_cost>", 
-        default = 1, help="Loss cost")
-
-    ### Param for clumpr ###
-    clumpr_parser = subparsers.add_parser('clumpr', help="Run clumpr")
-    clumpr_parser.add_argument("-d", type=float, metavar="<duplication_cost>", 
-        default = 2, help="Duplication cost")
-    clumpr_parser.add_argument("-t", type=float, metavar="<transfer_cost>", 
-        default = 3, help="Transfer cost")
-    clumpr_parser.add_argument("-l", type=float, metavar="<loss_cost>", 
-        default = 1, help="Loss cost")
-    clumpr_parser.add_argument("-k", type=int, metavar="<number_of_clusters>", help="Number of clusters")
-    clumpr_parser.add_argument("--medians", action="store_true", required=False,
-        help="Whether or not to print out medians for each cluster")
-    # Specifies how far down to go when finding splits
-    depth_or_n = clumpr_parser.add_mutually_exclusive_group(required=True)
-    depth_or_n.add_argument("--depth", type=int, metavar="<tree_depth>",
-        help="How far down to split the graph before clustering")
-    depth_or_n.add_argument("--nsplits", type=int, metavar="<tree_depth>",
-        help="Find at least n splits before combining the splits into clusters")
-    # What visualizations to produce
-    vis_type = clumpr_parser.add_mutually_exclusive_group(required=False)
-    vis_type.add_argument("--pdv-vis", action="store_true",
-        help="Visualize the resulting clusters using the Pairwise Distance")
-    vis_type.add_argument("--support-vis", action="store_true",
-        help="Visualize the resulting clusters using event supports")
-    # Which objective function to use
-    score = clumpr_parser.add_mutually_exclusive_group(required=True)
-    score.add_argument("--pdv", action="store_true",
-        help="Use the weighted average distance to evaluate clusters")
-    score.add_argument("--support", action="store_true",
-        help="Use the weighted average event support to evaluate clusters")
-
-    ### Parser for Histogram ###
-    histogram_parser = subparsers.add_parser('histogram', help="Run histogram")
-    histogram_parser.add_argument("-d", type=float, metavar="<duplication_cost>", 
-        default = 2, help="Duplication cost")
-    histogram_parser.add_argument("-t", type=float, metavar="<transfer_cost>", 
-        default = 3, help="Transfer cost")
-    histogram_parser.add_argument("-l", type=float, metavar="<loss_cost>", 
-        default = 1, help="Loss cost")
-    histogram_parser.add_argument("--histogram", metavar="<filename>", default="unset",     
-        nargs="?", help="Output the histogram at the path provided. \
-        If no filename is provided, outputs to a filename based on the input .newick file.")
-    histogram_parser.add_argument("--xnorm", action="store_true",
-        help="Normalize the x-axis so that the distances range between 0 and 1.")
-    histogram_parser.add_argument("--ynorm", action="store_true",
-        help="Normalize the y-axis so that the histogram is a probability distribution.")
-    histogram_parser.add_argument("--omit_zeros", action="store_true",
-        help="Omit the zero column of the histogram, which will always be the total number of reconciliations.")
-    histogram_parser.add_argument("--cumulative", action="store_true",
-        help="Make the histogram cumulative.")
-    histogram_parser.add_argument("--csv", metavar="<filename>", default="unset", nargs="?",
-        help="Output the histogram as a .csv file at the path provided. \
-        If no filename is provided, outputs to a filename based on the input .newick file.")
-    # Statistics to print
-    histogram_parser.add_argument("--stats", action="store_true",
-        help="Output statistics including the total number of MPRs, the diameter of MPR-space, and the average distance between MPRs.")
-    # Time it?
-    histogram_parser.add_argument("--time", action="store_true",
-        help="Time the diameter algorithm")
-    args = parser.parse_args()
-    if args.functionality == "histogram":
-        fname = Path(args.host)
-        cost_suffix = ".{}-{}-{}".format(args.d, args.t, args.l)
-        # If args is unset, use the original .newick file path but replace .newick with .pdf
-        if args.histogram is None:
-            args.histogram = str(fname.with_suffix(cost_suffix + ".pdf"))
-        # If it wasn't set by the arg parser, then set it to None (the option wasn't present)
-        elif args.histogram == "unset":
-            args.histogram = None
-        #TODO: check that the specified path has a matplotlib-compatible extension?
-        # Do the same for .csv
-        if args.csv is None:
-            args.csv = str(fname.with_suffix(cost_suffix + ".csv"))
-        elif args.csv == "unset":
-            args.csv = None
-        # If it was user-specified, check that it has a .csv extension
-        else:
-            c = Path(args.csv)
-            assert c.suffix == ".csv"
-
-    return args
-    
+import cli_commands.cluster
+import cli_commands.cost_regions
+import cli_commands.histogram
+import cli_commands.reconcile
 
 def main():
-    args = process_arg()
-    recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
-    if args.functionality == "costscape":
-        costscape.solve(recon_input, args.dl, args.dh, args.tl, args.th, args)
-    elif args.functionality == "reconcile":
-        recongraph_tools.reconcile_noninter(recon_input, args.d, args.t, args.l)
-    elif args.functionality == "histogram":
-        histogram_main.compute_pdv(args.host, recon_input, args.d, args.t, args.l, args)
-    elif args.functionality == "clumpr":
-        cluster_main.perform_clustering(recon_input, args.d, args.t, args.l, args.k, args)
+    parser = argparse.ArgumentParser("empress tool for duplication-transfer-loss maximum parsimony reconciliation")
 
+    # Create subparsers and setup the subparsers
+    subparsers = parser.add_subparsers(dest='command', help='Commands empress can run')
 
-if __name__ == "__main__": main()
+    cost_regions_parser = subparsers.add_parser('cost_regions',
+                                                help="Find cost regions that give the same reconciliations")
+    cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
+    reconcile_parser = subparsers.add_parser('reconcile', help="Find the reconciliation graph given the dtl costs")
+    cli_commands.reconcile.add_reconcile_to_parser(reconcile_parser)
+    histogram_parser = subparsers.add_parser('cluster',
+                                             help="Find pairwise distance histogram of reconciliation space")
+    cli_commands.histogram.add_histogram_to_parser(histogram_parser)
+    cluster_parser = subparsers.add_parser('cluster', help="Find cluster of reconciliations with same properties")
+    cli_commands.cluster.add_cluster_to_parser(cluster_parser)
+
+    # Determine which command we should run and run the correct command
+    args = parser.parse_args()
+
+    if args.command == "cost_regions":  # argparse - characters will be converted to _ characters
+        cli_commands.cost_regions.run_cost_regions(args)
+    elif args.command == "reconcile":
+        cli_commands.reconcile.run_cost_regions(args)
+    elif args.command == "histogram":
+        cli_commands.histogram.run_cost_regions(args)
+    elif args.command == "cluster":
+        cli_commands.cluster.run_cost_regions(args)
+
+if __name__ == "__main__":
+    main()

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -15,32 +15,45 @@ import cli_commands.reconcile
 def main():
     parser = argparse.ArgumentParser(
         description="Empress tool for duplication-transfer-loss maximum parsimony reconciliation.",
-        epilog="Show help for each command by running `python empress_cli.py <command> --help`"
+        epilog="Show help for each command by running `python empress_cli.py <command> --help`",
     )
 
     # Create subparsers and setup the subparsers
     subparsers = parser.add_subparsers(dest='command', help='Commands empress can run')
 
     cost_regions_parser = subparsers.add_parser(
-        'cost_regions', help="Find cost regions that give same maximum parsimony reconciliations"
+        'cost_regions',
+        description="Find cost regions that give same maximum parsimony reconciliations.",
+        help="find cost regions that give same maximum parsimony reconciliations",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
+
     reconcile_parser = subparsers.add_parser(
-        'reconcile', help="Find maximum parsimony reconciliations given duplication, transfer, and loss costs"
+        'reconcile',
+        description="Find maximum parsimony reconciliations given duplication, transfer, and loss costs.",
+        help="find maximum parsimony reconciliations given duplication, transfer, and loss costs",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     cli_commands.reconcile.add_reconcile_to_parser(reconcile_parser)
+
     histogram_parser = subparsers.add_parser(
-        'histogram', help="Find pairwise distance histogram of all reconciliations given duplication, transfer, "
-                          "and loss costs"
+        'histogram',
+        description="Find pairwise distance histogram of all reconciliations given duplication, transfer, and loss costs.",
+        help="find pairwise distance histogram of all reconciliations given duplication, transfer, and loss costs",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     cli_commands.histogram.add_histogram_to_parser(histogram_parser)
+
     cluster_parser = subparsers.add_parser(
-        'cluster', help="Find cluster of reconciliations with similar properties given duplication, transfer, "
-                          "and loss costs"
+        'cluster',
+        description="Find cluster of reconciliations with similar properties given duplication, transfer, and loss costs.",
+        help="find cluster of reconciliations with similar properties given duplication, transfer, and loss costs",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     cli_commands.cluster.add_cluster_to_parser(cluster_parser)
 
-    # Determine which command we should run and run the correct command
+    # Determine which command we should run and run it
     args = parser.parse_args()
 
     if args.command == "cost_regions":  # argparse automatically converts "-" to "_"
@@ -51,6 +64,7 @@ def main():
         cli_commands.histogram.run_cost_regions(args)
     elif args.command == "cluster":
         cli_commands.cluster.run_cost_regions(args)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Refactor command line interface into different files according to functionality. Modify description and help comments. Move the command in front of the host, parasite, and tip mapping input. Make input files and number of clusters positional arguments.

cli -- old:
```
$ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
                        --mapping examples/heliconius_mapping.mapping \
                        reconcile -d 4 -t 2 -l 0

$ python empress_cli.py --host examples/heliconius_host.nwk --parasite examples/heliconius_parasite.nwk \
                        --mapping examples/heliconius_mapping.mapping \
                        clumpr -k 3 --median --nsplits 8 --support
```
cli -- new:
```
$ python empress_cli.py reconcile examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
                                  examples/heliconius_mapping.mapping -d 4 -t 2 -l 0

$ python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
                                examples/heliconius_mapping.mapping clumpr 3 --median --n-splits 8 --support
```

Help -- old:
```
$ python empress_cli.py --help
usage: empress_cli.py [-h] --host <host_file> --parasite <parasite_file>
                      --mapping <mapping_file>
                      {costscape,reconcile,clumpr,histogram} ...

positional arguments:
  {costscape,reconcile,clumpr,histogram}
                        Functions empress can run
    costscape           Run costscape
    reconcile           Run reconcile
    clumpr              Run clumpr
    histogram           Run histogram

optional arguments:
  -h, --help            show this help message and exit
  --host <host_file>    The path to the file with the input host tree.
  --parasite <parasite_file>
                        The path to the file with the input parasite tree.
  --mapping <mapping_file>
                        The path to the file with the tip mapping.
```
Help -- new:
```
python empress_cli.py --help       
usage: empress_cli.py [-h] {cost_regions,reconcile,histogram,cluster} ...

Empress tool for duplication-transfer-loss maximum parsimony reconciliation.

positional arguments:
  {cost_regions,reconcile,histogram,cluster}
                        Commands empress can run
    cost_regions        find cost regions that give same maximum parsimony
                        reconciliations
    reconcile           find maximum parsimony reconciliations given
                        duplication, transfer, and loss costs
    histogram           find pairwise distance histogram of all
                        reconciliations given duplication, transfer, and loss
                        costs
    cluster             find cluster of reconciliations with similar
                        properties given duplication, transfer, and loss costs

optional arguments:
  -h, --help            show this help message and exit

Show help for each command by running `python empress_cli.py <command> --help`
```

Help -- old:
```
$ python empress_cli.py clumpr --help
usage: empress_cli.py clumpr [-h] [-d <duplication_cost>] [-t <transfer_cost>]
                             [-l <loss_cost>] [-k <number_of_clusters>]
                             [--medians]
                             (--depth <tree_depth> | --nsplits <tree_depth>)
                             [--pdv-vis | --support-vis] (--pdv | --support)

optional arguments:
  -h, --help            show this help message and exit
  -d <duplication_cost>
                        Duplication cost
  -t <transfer_cost>    Transfer cost
  -l <loss_cost>        Loss cost
  -k <number_of_clusters>
                        Number of clusters
  --medians             Whether or not to print out medians for each cluster
  --depth <tree_depth>  How far down to split the graph before clustering
  --nsplits <tree_depth>
                        Find at least n splits before combining the splits
                        into clusters
  --pdv-vis             Visualize the resulting clusters using the Pairwise
                        Distance
  --support-vis         Visualize the resulting clusters using event supports
  --pdv                 Use the weighted average distance to evaluate clusters
  --support             Use the weighted average event support to evaluate
                        clusters
```
Help -- new:
```
$ python empress_cli.py cluster --help
usage: empress_cli.py cluster [-h] [-d <duplication_cost>]
                              [-t <transfer_cost>] [-l <loss_cost>]
                              [--medians]
                              (--depth <tree_depth> | --n-splits <tree_depth>)
                              [--pdv-vis | --support-vis] (--pdv | --support)
                              <host_file> <parasite_file> <mapping_file>
                              <number_of_clusters>

Find cluster of reconciliations with similar properties given duplication,
transfer, and loss costs.

positional arguments:
  <host_file>           file path to the host tree
  <parasite_file>       file path to the parasite tree
  <mapping_file>        file path to the tip mapping
  <number_of_clusters>  Number of clusters

optional arguments:
  -h, --help            show this help message and exit
  -d <duplication_cost>, --dup-cost <duplication_cost>
                        cost incurred on each duplication event (default: 2)
  -t <transfer_cost>, --trans-cost <transfer_cost>
                        cost incurred on each transfer event (default: 3)
  -l <loss_cost>, --loss-cost <loss_cost>
                        cost incurred on each loss event (default: 1)
  --medians             whether or not to print out medians for each cluster
                        (default: False)
  --depth <tree_depth>  how far down to split the graph before clustering
                        (default: None)
  --n-splits <tree_depth>
                        find at least n splits before combining the splits
                        into clusters (default: None)
  --pdv-vis             visualize the resulting clusters using the Pairwise
                        Distance (default: False)
  --support-vis         visualize the resulting clusters using event supports
                        (default: False)
  --pdv                 use the weighted average distance to evaluate clusters
                        (default: False)
  --support             use the weighted average event support to evaluate
                        clusters (default: False)
```