### PR TITLE
fix tree object parent node not populated

### DIFF
--- a/empress/recon_vis/utils.py
+++ b/empress/recon_vis/utils.py
@@ -62,7 +62,7 @@ def _dict_to_tree_helper(tree_dict, root_edge):
         new_node.left_node = new_left_node
         new_left_node.parent_node = new_node
         new_node.right_node = new_right_node
-        new_left_node.parent_node = new_node
+        new_right_node.parent_node = new_node
         return new_node
 
 # ReconGraph utilities


### PR DESCRIPTION
Fix a typo in the function ``_dict_to_tree_helper`` in ``utils.py``  so that it correctly populates the parent node of each node in the ``Tree`` object.