### PR TITLE
Make parser prints error if command not specified

### DIFF
--- a/.github/workflows/integration-tests-and-draw-tests.yml
+++ b/.github/workflows/integration-tests-and-draw-tests.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Run empress_cli help
       run: |
         pipenv run python empress_cli.py --help
-    - name: Run cost_regions help
+    - name: Run cost-regions help
       run: |
-        pipenv run python empress_cli.py cost_regions --help
+        pipenv run python empress_cli.py cost-regions --help
     - name: Run cost region example in Readme.md
       run: |
-        pipenv run python empress_cli.py cost_regions examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
+        pipenv run python empress_cli.py cost-regions examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 --outfile costscape-example-img.pdf --log
     - name: Run reconcile example in Readme.md
       run: |
         pipenv run python empress_cli.py reconcile examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping -d 4 -t 2 -l 0

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ python empress_cli.py <command> hostfile parasitefile mappingfile
 
 For example, to run Costscape with default parameters, you run:
 ```bash
-python empress_cli.py cost_regions hostfile parasitefile mappingfile 
+python empress_cli.py cost-regions hostfile parasitefile mappingfile 
 ```
 
 For specific parameters of each functionality, consult the list below:
@@ -51,7 +51,7 @@ Note: value in parenthesis denotes default value, asterisk denotes boolean flags
 For example, the following example runs Costscape with duplication low value of 0.5, duplication high value of 10, transfer low value of 0.5, 
 and transfer high value of 10, that saves to a file called `foo.pdf` display it in log scale.
 ```bash
-$ python empress_cli.py cost_regions examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
+$ python empress_cli.py cost-regions examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
                                      examples/heliconius_mapping.mapping -tl 0.5 -th 10 -dl 0.5 -dh 10 \
                                      --outfile costscape-example-img.pdf --log
 ```

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -19,7 +19,7 @@ def main():
     )
 
     # Create subparsers and setup the subparsers
-    subparsers = parser.add_subparsers(dest='command', help='Commands empress can run')
+    subparsers = parser.add_subparsers(dest='command', help='Commands empress can run', required=True)
 
     cost_regions_description = "Find cost regions that give same maximum parsimony reconciliations."
     cost_regions_parser = subparsers.add_parser(

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -23,7 +23,7 @@ def main():
 
     cost_regions_description = "Find cost regions that give same maximum parsimony reconciliations."
     cost_regions_parser = subparsers.add_parser(
-        'cost_regions', description=cost_regions_description, help=cost_regions_description.lower().rstrip('.'),
+        'cost-regions', description=cost_regions_description, help=cost_regions_description.lower().rstrip('.'),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # print default value
     )
     cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
@@ -54,7 +54,7 @@ def main():
     # Determine which command we should run and run it
     args = parser.parse_args()
 
-    if args.command == "cost_regions":  # argparse automatically converts "-" to "_"
+    if args.command == "cost-regions":
         cli_commands.cost_regions.run_cost_regions(args)
     elif args.command == "reconcile":
         cli_commands.reconcile.run_reconcile(args)


### PR DESCRIPTION
Old:
```
$ python empress_cli.py                           
# passes without error
$
```
New:
```
$ python empress_cli.py                           
usage: empress_cli.py [-h] {cost-regions,reconcile,histogram,cluster} ...
empress_cli.py: error: the following arguments are required: command
$
```
Also change command name `cost_regions` to `cost-regions`.