### PR TITLE
Change cost regions title to "Event cost regions" if title not provided

### DIFF
--- a/empress/xscape/plotcosts_analytic.py
+++ b/empress/xscape/plotcosts_analytic.py
@@ -107,7 +107,10 @@ def plot_costs_on_axis(axes: Axes, cost_vectors, transfer_min, transfer_max, dup
     leg = axes.legend()
     for i in range(len(leg.legendHandles)):  # adjust legend marker thickness
         leg.legendHandles[i].set_linewidth(2.0)
-    axes.set_title("Costscape: %s" % title)
+    if title is None:
+        axes.set_title("Event cost regions")
+    else:
+        axes.set_title("Costscape: %s" % title)
 
 def plotcosts(CVlist, transfer_min, transfer_max, dup_min, dup_max, outfile,
               log=True, display=False, verbose=False):


### PR DESCRIPTION
If title argument provided to plot_costs_on_axis is None, set the title to "Event cost regions".

Resolves #132 .

Before:
<img width="400" alt="Screen Shot 2020-07-14 at 6 54 34 PM" src="https://user-images.githubusercontent.com/19219105/87494323-882be100-c603-11ea-903f-a941b6c478b2.png">
After:
<img width="400" alt="Screen Shot 2020-07-14 at 6 54 09 PM" src="https://user-images.githubusercontent.com/19219105/87494326-8a8e3b00-c603-11ea-92e4-d59be9310f4f.png">
