### PR TITLE
Add pkg_resources.py2_warn to pyinstaller

### DIFF
--- a/pyinstaller_spec/empress_gui_debug.spec
+++ b/pyinstaller_spec/empress_gui_debug.spec
@@ -9,7 +9,9 @@ a = Analysis(['../empress_gui.py'],
              pathex=['pyinstaller_spec'],
              binaries=[],
              datas=[("../assets", "./assets")],
-             hiddenimports=[],
+             # pkg_resources.py2_warn hidden import needed if setuptools>=45.0.0
+             # https://github.com/pypa/setuptools/issues/1963#issuecomment-574265532
+             hiddenimports=['pkg_resources.py2_warn'],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],


### PR DESCRIPTION
If setuptools version is greater than or equal to 45.0.0, it will produce the error
```
[1072] Failed to execute script pyi_rth_pkgres
Traceback (most recent call last):
  File "site-packages/PyInstaller/loader/rthooks/pyi_rth_pkgres.py", line 11, in <module>
  File "/<virtualenv-path>/lib/python3.6/site-packages/PyInstaller/loader/pyimod03_importers.py", line 631, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages/pkg_resources/__init__.py", line 86, in <module>
ModuleNotFoundError: No module named 'pkg_resources.py2_warn'
```
Either downgrading the setuptools version or adding pkg_resources.py2_warn hidden import resolves this problem. Tested on MacOS Catalina 10.15.5.

See https://github.com/pypa/setuptools/issues/1963#issuecomment-574265532