### PR TITLE
(outdated)GUI: separate reconciliation solutions and add toggle buttons for "One per cluster" + bring new windows to the front

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,8 +1,3 @@
-[[source]]
-url = "https://pypi.python.org/simple"
-verify_ssl = true
-name = "pypi"
-
 [requires]
 python_version = '3.7'
 
@@ -10,17 +5,11 @@ python_version = '3.7'
 biopython = '*'
 networkx = '*'
 pydot = '*'
-# Pyinstaller doesn't work with matplotlib 3.3.0
-# https://github.com/pyinstaller/pyinstaller/pull/5006
-# TODO: change to matplotlib = '*' after fix is released
-matplotlib = '==3.2.*'
+matplotlib = '*'
 shapely = '*'
 numpy = '*'
 
 [dev-packages]
 coverage = '*'
 flake8 = "*"
-# Correctly locate macos python.org built-in tcl/tk
-# https://github.com/pyinstaller/pyinstaller/pull/5010
-# TODO: change to pyinstaller = '*' after fix is released
-pyinstaller = {editable = true, git = "https://github.com/ssantichaivekin/pyinstaller.git", ref = "tcl-tk-macos-bugfix-frozen"}
+pyinstaller = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6f6ab30b61e9a032d21fb3e99d3767efde9b64b463c67103c283c639d613beaf"
+            "sha256": "9fd12b2cd2357326f184fb2a4fe0a44a00db61e701b175e6ea16d91d631a6b37"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -10,7 +10,7 @@
         "sources": [
             {
                 "name": "pypi",
-                "url": "https://pypi.python.org/simple",
+                "url": "https://pypi.org/simple",
                 "verify_ssl": true
             }
         ]
@@ -74,7 +74,6 @@
                 "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8",
                 "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==1.2.0"
         },
         "matplotlib": {
@@ -152,7 +151,6 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -160,7 +158,6 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "shapely": {
@@ -193,7 +190,6 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         }
     },
@@ -266,7 +262,6 @@
                 "sha256:0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432",
                 "sha256:c500f02867515e6c60a27875b408920d18332ddf96b4035ef03beddd782d4281"
             ],
-            "markers": "sys_platform == 'darwin' and sys_platform == 'darwin'",
             "version": "==1.14"
         },
         "mccabe": {
@@ -281,7 +276,6 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pyflakes": {
@@ -289,20 +283,20 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pyinstaller": {
-            "editable": true,
-            "git": "https://github.com/ssantichaivekin/pyinstaller.git",
-            "ref": "4b880a028b4583342ac3bf3f2f95ee240e05a323"
+            "hashes": [
+                "sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7"
+            ],
+            "index": "pypi",
+            "version": "==3.6"
         },
         "zipp": {
             "hashes": [
                 "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
                 "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.1.0"
         }
     }

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -152,7 +152,7 @@ class ReconGraphWrapper(Drawable):
         """
         recongraph_visualization.visualize_and_save(self.recongraph, fname)
 
-    def stats(self, num_trials: int = 100):
+    def stats(self, num_trials: int = 50):
         _, costs, p = statistics.stats(self.recon_input, self.dup_cost, self.trans_cost, self.loss_cost, num_trials)
         return costs, p
 
@@ -196,7 +196,7 @@ class ReconGraphWrapper(Drawable):
 
         score = cluster_util.mk_pdv_score(host_tree, parasite_tree, parasite_root)
 
-        graphs, scores, _ = cluster_util.cluster_graph(self.recongraph, parasite_root, score, 4, n)
+        graphs, scores, _ = cluster_util.cluster_graph(self.recongraph, parasite_root, score, 4, n, 200)
         new_graphs = []
         for graph in graphs:
             roots = _find_roots(graph)

--- a/empress/cluster/cluster_main.py
+++ b/empress/cluster/cluster_main.py
@@ -158,9 +158,9 @@ def perform_clustering(tree_data, d, t, l, k, args):
     score = mk_score(species_tree, gene_tree, gene_root)
     # Actually perform the clustering
     if args.depth is not None:
-        graphs, scores, _ = cluster_util.cluster_graph(recon_g, gene_root, score, args.depth, k)
+        graphs, scores, _ = cluster_util.cluster_graph(recon_g, gene_root, score, args.depth, k, 200)
     elif args.n_splits is not None:
-        graphs, scores, _ = cluster_util.cluster_graph_n(recon_g, gene_root, score, args.n_splits, mpr_count, k)
+        graphs, scores, _ = cluster_util.cluster_graph_n(recon_g, gene_root, score, args.n_splits, mpr_count, k, 200)
     else:
         assert False
     # Visualization

--- a/empress/cluster/cluster_util.py
+++ b/empress/cluster/cluster_util.py
@@ -480,7 +480,7 @@ def combine(split_gs, g_score, k, mpr_counter):
     # the second is for k+1 clusters, etc.
     return split_gs, scores[::-1], local_scores[::-1]
 
-def cluster_graph_n(graph, gene_root, score, n, mpr_count, k, max_splits=None):
+def cluster_graph_n(graph, gene_root, score, n, mpr_count, k, max_splits):
     """
     Find k clusters within MPRs of g by first finding at least n splits
     then merging them by WAS.
@@ -496,14 +496,13 @@ def cluster_graph_n(graph, gene_root, score, n, mpr_count, k, max_splits=None):
     """
     # First split the graph
     gs = full_split_n(graph, gene_root, n, mpr_count)
-    if max_splits is not None and len(gs) > max_splits:
-        print("Too many splits: {}".format(len(gs)))
+    if len(gs) > max_splits:
         return None
     mpr_counter = mk_count_mprs(gene_root)
     # Then recombine those splits until we have k graphs
     return combine(gs, score, k, mpr_counter)
 
-def cluster_graph(graph, gene_root, distance, depth, k, max_splits=None):
+def cluster_graph(graph, gene_root, distance, depth, k, max_splits):
     """
     Find k clusters within MPRs of g using a depth-splitting method
     then merging by WAS.
@@ -512,8 +511,7 @@ def cluster_graph(graph, gene_root, distance, depth, k, max_splits=None):
     """
     # First split the graph
     gs = full_split(graph, gene_root, depth)
-    if max_splits is not None and len(gs) > max_splits:
-        print("Too many splits: {}".format(len(gs)))
+    if len(gs) > max_splits:
         return None
     mpr_counter = mk_count_mprs(gene_root)
     # Then recombine those splits until we have k graphs

--- a/empress/xscape/plotcosts_analytic.py
+++ b/empress/xscape/plotcosts_analytic.py
@@ -107,10 +107,7 @@ def plot_costs_on_axis(axes: Axes, cost_vectors, transfer_min, transfer_max, dup
     leg = axes.legend()
     for i in range(len(leg.legendHandles)):  # adjust legend marker thickness
         leg.legendHandles[i].set_linewidth(2.0)
-    if title is None:
-        axes.set_title("Event cost regions")
-    else:
-        axes.set_title("Costscape: %s" % title)
+    axes.set_title("Costscape: %s" % title)
 
 def plotcosts(CVlist, transfer_min, transfer_max, dup_min, dup_max, outfile,
               log=True, display=False, verbose=False):

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -2,15 +2,11 @@
 
 import tkinter as tk
 from tkinter import messagebox
-# You have to import filedialog explicitly for it to work across platforms
-# see https://stackoverflow.com/a/36165227/2860949
-from tkinter import filedialog
 import os
 import sys
-import pathlib
-
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+import pathlib
 
 import empress
 from empress import input_reader
@@ -219,9 +215,9 @@ class App(tk.Frame):
         self.cost_space_window = None
         self.entire_space_window = None
         self.set_num_cluster_window = None
+        self.view_solution_space_window_after_setting_clusters = None
         self.one_MPR_window = None
-        self.view_solution_space_window = None
-        self.view_reconciliations_window = None
+        self.solution_window = None
         self.view_pvalue_histogram_window = None
     
     def refresh_when_reload_host(self):
@@ -319,14 +315,16 @@ class App(tk.Frame):
         if self.set_num_cluster_window is not None and self.set_num_cluster_window.winfo_exists():
             self.set_num_cluster_window.destroy()
 
-        if self.view_solution_space_window is not None and self.view_solution_space_window.winfo_exists():
-            self.view_solution_space_window.destroy()
+        if self.view_solution_space_window_after_setting_clusters is not None and self.view_solution_space_window_after_setting_clusters.winfo_exists():
+            self.view_solution_space_window_after_setting_clusters.destroy()
 
         if self.one_MPR_window is not None and self.one_MPR_window.winfo_exists():
             self.one_MPR_window.destroy()
 
-        if self.view_reconciliations_window is not None and self.view_reconciliations_window.winfo_exists():
-            self.view_reconciliations_window.destroy()
+        if self.num_cluster is not None:
+            for i in range(self.num_cluster):
+                if self.solution_window is not None and self.solution_window.winfo_exists():
+                    self.solution_window.destroy()
 
         if self.view_pvalue_histogram_window is not None and self.view_pvalue_histogram_window.winfo_exists():
             self.view_pvalue_histogram_window.destroy()
@@ -343,14 +341,13 @@ class App(tk.Frame):
         if self.load_files_var.get() == "Load host tree file":
             self.load_files_var.set("Load files")
             # initialdir is set to be the current working directory
-            input_file = filedialog.askopenfilename(initialdir=os.getcwd(), title="Select a host file",
+            input_file = tk.filedialog.askopenfilename(initialdir=os.getcwd(), title="Select a host file",
                                                        filetypes=[("Newick Trees", "*.nwk *.newick *.tree")])
             if input_file != "":
                 try:
                     self.recon_input.read_host(input_file)
                 except Exception as e:
                     messagebox.showinfo("Warning", "Error: " + str(e))
-                    return
                 self.host_file_path = input_file
                 # Force a sequence of loading host tree file first, and then parasite tree file, and then mapping file
                 self.load_files_dropdown['menu'].entryconfigure("Load parasite tree file", state = "disabled")
@@ -363,14 +360,13 @@ class App(tk.Frame):
         elif self.load_files_var.get() == "Load parasite tree file":
             self.load_files_var.set("Load files")
             # initialdir is set to be the same as that of the host file chosen by the user
-            input_file = filedialog.askopenfilename(initialdir=pathlib.Path(self.host_file_path).parent, title="Select a parasite file",
+            input_file = tk.filedialog.askopenfilename(initialdir=pathlib.Path(self.host_file_path).parent, title="Select a parasite file",
                                                        filetypes=[("Newick Trees", "*.nwk *.newick *.tree")])
             if input_file != "":
                 try:
                     self.recon_input.read_parasite(input_file)
                 except Exception as e:
                     messagebox.showinfo("Warning", "Error: " + str(e))
-                    return
                 self.parasite_file_path = input_file
                 self.refresh_when_reload_parasite()
                 self.update_parasite_info()
@@ -380,14 +376,13 @@ class App(tk.Frame):
         elif self.load_files_var.get() == "Load mapping file":
             self.load_files_var.set("Load files")
             # initialdir is set to be the same as that of the host file chosen by the user
-            input_file = filedialog.askopenfilename(initialdir=pathlib.Path(self.host_file_path).parent, title="Select a mapping file",
+            input_file = tk.filedialog.askopenfilename(initialdir=pathlib.Path(self.host_file_path).parent, title="Select a mapping file",
                                                        filetypes=[("Tip mapping", "*.mapping")])
             if input_file != "":
                 try:
                     self.recon_input.read_mapping(input_file)
                 except Exception as e:
                     messagebox.showinfo("Warning", "Error: " + str(e))
-                    return
                 self.mapping_file_path = input_file
                 self.refresh_when_reload_mapping()
                 self.update_mapping_info()
@@ -429,12 +424,17 @@ class App(tk.Frame):
         self.tanglegram_window = tk.Toplevel(self.master)
         self.tanglegram_window.geometry("600x600")
         self.tanglegram_window.title("Tanglegram")
+        # Bring the new tkinter window to the front
+        self.tanglegram_window.attributes('-topmost', True)
+        self.tanglegram_window.focus_force()
+        self.tanglegram_window.bind('<FocusIn>', self.OnFocusIn)
         # Creates a new frame
         tanglegram_frame = tk.Frame(self.tanglegram_window)
         tanglegram_frame.pack(fill=tk.BOTH, expand=1)
         tanglegram_frame.pack_propagate(False)
-        fig = self.recon_input.draw()
-        canvas = FigureCanvasTkAgg(fig, tanglegram_frame)
+        self.fig_tanglegram = self.recon_input.draw()
+        self.tanglegram_window.protocol("WM_DELETE_WINDOW", self.tanglegram_figure_on_closing)
+        canvas = FigureCanvasTkAgg(self.fig_tanglegram, tanglegram_frame)
         canvas.draw()
         canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         # The toolbar allows the user to zoom in/out, drag the graph and save the graph
@@ -449,6 +449,10 @@ class App(tk.Frame):
         self.cost_space_window = tk.Toplevel(self.master)
         self.cost_space_window.geometry("550x550")
         self.cost_space_window.title("Matplotlib Graph - Cost regions")
+        # Bring the new tkinter window to the front
+        self.cost_space_window.attributes('-topmost', True)
+        self.cost_space_window.focus_force()
+        self.cost_space_window.bind('<FocusIn>', self.OnFocusIn)
         # Creates a new frame
         plt_frame = tk.Frame(self.cost_space_window)
         plt_frame.pack(fill=tk.BOTH, expand=1)
@@ -638,6 +642,10 @@ class App(tk.Frame):
             self.entire_space_window = tk.Toplevel(self.master)
             self.entire_space_window.geometry("600x600")
             self.entire_space_window.title("Entire space")
+            # Bring the new tkinter window to the front
+            self.entire_space_window.attributes('-topmost', True)
+            self.entire_space_window.focus_force()
+            self.entire_space_window.bind('<FocusIn>', self.OnFocusIn)
             # Creates a new frame
             plt_frame = tk.Frame(self.entire_space_window)
             plt_frame.pack(fill=tk.BOTH, expand=1)
@@ -661,6 +669,10 @@ class App(tk.Frame):
         self.set_num_cluster_window = tk.Toplevel(self.master)
         self.set_num_cluster_window.geometry("300x200")
         self.set_num_cluster_window.title("Set the number of clusters")
+        # Bring the new tkinter window to the front
+        self.set_num_cluster_window.attributes('-topmost', True)
+        self.set_num_cluster_window.focus_force()
+        self.set_num_cluster_window.bind('<FocusIn>', self.OnFocusIn)
         # Creates a new frame
         self.set_num_cluster_frame = tk.Frame(self.set_num_cluster_window)
         self.set_num_cluster_frame.pack(fill=tk.BOTH, expand=tk.YES)
@@ -730,12 +742,28 @@ class App(tk.Frame):
             for i in range(len(clusters)):
                 App.medians.append(clusters[i].median())
 
-        if self.view_solution_space_window is not None and self.view_solution_space_window.winfo_exists():
-            self.view_solution_space_window.destroy()
-        if self.view_reconciliations_window is not None and self.view_reconciliations_window.winfo_exists():
-            self.view_reconciliations_window.destroy()
+        if self.view_solution_space_window_after_setting_clusters is not None and self.view_solution_space_window_after_setting_clusters.winfo_exists():
+            self.view_solution_space_window_after_setting_clusters.destroy()
+
+        if self.num_cluster is not None:
+            for i in range(self.num_cluster):
+                if self.solution_window is not None and self.solution_window.winfo_exists():
+                    self.solution_window.destroy()
+
         if self.view_pvalue_histogram_window is not None and self.view_pvalue_histogram_window.winfo_exists():
             self.view_pvalue_histogram_window.destroy()
+
+    def open_window_solution_space(self):
+        """Pop up a new tkinter window to display the solution space after entering the number of clusters."""
+        if self.num_cluster is not None:
+            self.view_solution_space_window_after_setting_clusters = tk.Toplevel(self.master)
+            self.view_solution_space_window_after_setting_clusters.geometry("900x900")
+            self.view_solution_space_window_after_setting_clusters.title("View reconciliation space")
+            # Bring the new tkinter window to the front
+            self.view_solution_space_window_after_setting_clusters.attributes('-topmost', True)
+            self.view_solution_space_window_after_setting_clusters.focus_force()
+            self.view_solution_space_window_after_setting_clusters.bind('<FocusIn>', self.OnFocusIn)
+            SolutionSpaceWindow(self.view_solution_space_window_after_setting_clusters)
 
     def select_from_view_reconciliations_dropdown(self, event):
         """When "View reconciliations" dropdown is clicked."""
@@ -745,27 +773,30 @@ class App(tk.Frame):
             self.one_MPR_window = tk.Toplevel(self.master)
             self.one_MPR_window.geometry("600x600")
             self.one_MPR_window.title("One MPR")
+            # Bring the new tkinter window to the front
+            self.one_MPR_window.attributes('-topmost', True)
+            self.one_MPR_window.focus_force()
+            self.one_MPR_window.bind('<FocusIn>', self.OnFocusIn)
             ReconciliationsOneMPRWindow(self.one_MPR_window)
 
         elif self.view_reconciliations_var.get() == "One per cluster":
             self.view_reconciliations_var.set("View reconciliations")
             self.open_window_reconciliations()
 
-    def open_window_solution_space(self):
-        """Pop up a new tkinter window to display the solution space."""
-        if self.num_cluster is not None:
-            self.view_solution_space_window = tk.Toplevel(self.master)
-            self.view_solution_space_window.geometry("900x900")
-            self.view_solution_space_window.title("View reconciliation space")
-            SolutionSpaceWindow(self.view_solution_space_window)
-
     def open_window_reconciliations(self):
-        """Pop up a new tkinter window to display the reconciliations."""
+        """Pop up new tkinter windows to display one reconciliation per cluster."""
         if self.num_cluster is not None:
-            self.view_reconciliations_window = tk.Toplevel(self.master)
-            self.view_reconciliations_window.geometry("900x900")
-            self.view_reconciliations_window.title("View reconciliations")
-            ReconciliationsOnePerClusterWindow(self.view_reconciliations_window)
+            solution_number = 1
+            for solution in App.medians:
+                self.solution_window = tk.Toplevel(self.master)
+                self.solution_window.geometry("800x800")
+                self.solution_window.title("View reconciliations " + str(solution_number))
+                # Bring the new tkinter window to the front
+                self.solution_window.attributes('-topmost', True)
+                self.solution_window.focus_force()
+                self.solution_window.bind('<FocusIn>', self.OnFocusIn)
+                ReconciliationsOnePerClusterWindow(self.solution_window, solution)
+                solution_number = solution_number + 1
 
     def open_window_pvalue_histogram(self):
         """Pop up a new tkinter window to display the p-value histogram."""
@@ -773,7 +804,22 @@ class App(tk.Frame):
         self.view_pvalue_histogram_window = tk.Toplevel(self.master)
         self.view_pvalue_histogram_window.geometry("700x700")
         self.view_pvalue_histogram_window.title("p-value Histogram")
+        # Bring the new tkinter window to the front
+        self.view_pvalue_histogram_window.attributes('-topmost', True)
+        self.view_pvalue_histogram_window.focus_force()
+        self.view_pvalue_histogram_window.bind('<FocusIn>', self.OnFocusIn)
         PValueHistogramWindow(self.view_pvalue_histogram_window)
+
+    def OnFocusIn(self, event):
+        """Bring newly created tkinter window to the front until user interacts with it, i.e., taking focus.."""
+        if type(event.widget).__name__ == 'Tk':
+            event.widget.attributes('-topmost', False)
+
+    def tanglegram_figure_on_closing(self):
+        """Close and remove matplotlib figures when the tkinter window is destroyed."""
+        self.fig_tanglegram.clear()
+        #plt.close(self.fig_tanglegram)
+        self.tanglegram_window.destroy()
 
 # View reconciliation space - Clusters
 class SolutionSpaceWindow(tk.Frame):
@@ -820,10 +866,10 @@ class ReconciliationsOneMPRWindow(tk.Frame):
         self.draw_one_MPR()
 
     def draw_one_MPR(self):
-        self.fig = App.recon_graph.median().draw(
+        self.one_mpr_fig = App.recon_graph.median().draw(
             show_internal_labels=self.show_internal_node_names_boolean, 
             show_freq=self.show_event_frequencies_boolean)
-        self.canvas = FigureCanvasTkAgg(self.fig, self.frame)
+        self.canvas = FigureCanvasTkAgg(self.one_mpr_fig, self.frame)
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         # The toolbar allows the user to zoom in/out, drag the graph and save the graph
@@ -847,38 +893,71 @@ class ReconciliationsOneMPRWindow(tk.Frame):
         show_event_frequencies_checkbutton.pack(side=tk.LEFT)
 
     def update_one_mpr(self):
+        # self.one_mpr_fig.clear()
+        # plt.close(self.one_mpr_fig)
         self.canvas.get_tk_widget().destroy()
-        self.fig = App.recon_graph.median().draw(
+        self.one_mpr_fig = App.recon_graph.median().draw(
             show_internal_labels=self.show_internal_node_names_boolean.get(),
             show_freq=self.show_event_frequencies_boolean.get()
         )
-        self.canvas = FigureCanvasTkAgg(self.fig, self.frame)
+        self.canvas = FigureCanvasTkAgg(self.one_mpr_fig, self.frame)
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
 # View reconciliations - One per cluster
 class ReconciliationsOnePerClusterWindow(tk.Frame):
-    def __init__(self, master):
+    def __init__(self, master, recon_solution):
         super().__init__(master)
+        self.recon_solution = recon_solution
         self.master = master
+        self.master.grid_rowconfigure(0, weight=5)
+        self.master.grid_rowconfigure(1, weight=1)
+        self.master.grid_columnconfigure(0, weight=1)
         self.frame = tk.Frame(self.master)
-        self.frame.pack(fill=tk.BOTH, expand=1)
-        self.frame.pack_propagate(False)
+        self.frame.grid(row=0, column=0, sticky="nsew")
+        self.frame.grid_propagate(False)
+        self.checkboxes_frame = tk.Frame(self.master)
+        self.checkboxes_frame.grid(row=1, column=0)
+        self.checkboxes_frame.grid_propagate(False)
+        self.create_checkboxes()
         self.draw_median_recons()
+
+    def create_checkboxes(self):
+        self.show_internal_node_names_boolean = tk.BooleanVar()
+        self.show_internal_node_names_boolean.set(tk.TRUE)
+        show_internal_node_names_checkbutton = tk.Checkbutton(self.checkboxes_frame, 
+            text="Display internal node names", variable=self.show_internal_node_names_boolean, 
+            command=self.update_median_recons)
+        show_internal_node_names_checkbutton.pack(side=tk.LEFT)
+
+        self.show_event_frequencies_boolean = tk.BooleanVar()
+        self.show_event_frequencies_boolean.set(tk.TRUE)
+        show_event_frequencies_checkbutton = tk.Checkbutton(self.checkboxes_frame, 
+            text="Display frequencies", variable=self.show_event_frequencies_boolean, 
+            command=self.update_median_recons)
+        show_event_frequencies_checkbutton.pack(side=tk.LEFT)
+
     def draw_median_recons(self):
-        if len(App.medians) == 1:
-            fig = App.medians[0].draw()
-        else:
-            fig, axs = plt.subplots(1, len(App.medians))
-            for i in range(len(App.medians)):
-                App.medians[i].draw_on(axs[i])
-        canvas = FigureCanvasTkAgg(fig, self.frame)
-        canvas.draw()
-        canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self.recon_solution_fig = self.recon_solution.draw(
+            show_internal_labels=self.show_internal_node_names_boolean, 
+            show_freq=self.show_event_frequencies_boolean)
+        self.canvas = FigureCanvasTkAgg(self.recon_solution_fig, self.frame)
+        self.canvas.draw()
+        self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         # The toolbar allows the user to zoom in/out, drag the graph and save the graph
-        toolbar = NavigationToolbar2Tk(canvas, self.frame)
+        toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
         toolbar.update()
-        canvas.get_tk_widget().pack(side=tk.TOP)
+        self.canvas.get_tk_widget().pack(side=tk.TOP)
+
+    def update_median_recons(self):
+        self.canvas.get_tk_widget().destroy()
+        self.recon_solution_fig = self.recon_solution.draw(
+            show_internal_labels=self.show_internal_node_names_boolean.get(),
+            show_freq=self.show_event_frequencies_boolean.get()
+        )
+        self.canvas = FigureCanvasTkAgg(self.recon_solution_fig, self.frame)
+        self.canvas.draw()
+        self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
 # p-value Histogram
 class PValueHistogramWindow(tk.Frame):

--- a/pyinstaller_spec/empress_gui_app.spec
+++ b/pyinstaller_spec/empress_gui_app.spec
@@ -9,9 +9,7 @@ a = Analysis(['../empress_gui.py'],
              pathex=['pyinstaller_spec'],
              binaries=[],
              datas=[("../assets", "./assets")],
-             # pkg_resources.py2_warn hidden import needed if setuptools>=45.0.0
-             # https://github.com/pypa/setuptools/issues/1963#issuecomment-574265532
-             hiddenimports=['pkg_resources.py2_warn'],
+             hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],

--- a/pyinstaller_spec/empress_gui_debug.spec
+++ b/pyinstaller_spec/empress_gui_debug.spec
@@ -9,9 +9,7 @@ a = Analysis(['../empress_gui.py'],
              pathex=['pyinstaller_spec'],
              binaries=[],
              datas=[("../assets", "./assets")],
-             # pkg_resources.py2_warn hidden import needed if setuptools>=45.0.0
-             # https://github.com/pypa/setuptools/issues/1963#issuecomment-574265532
-             hiddenimports=['pkg_resources.py2_warn'],
+             hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],


### PR DESCRIPTION
When we choose "View reconciliations" and then use the "One per cluster" option, the buttons for toggling event frequency and internal node names are added.  Also, the gui is changed to pop up a separate window for each solution rather than displaying several of them in one window. I have tested the new features using the examples in the empress folder. 
<img width="1279" alt="Screen Shot 2020-07-17 at 4 37 03 PM" src="https://user-images.githubusercontent.com/54883284/87766475-c9163680-c84b-11ea-902c-ffda430df516.png">
Issue: Only one "One per cluster" window can be closed when it becomes irrelevant (loading in new files/ compute reconciliations again). Ideally, all irrelevant "One per cluster" windows should be closed automatically as what the gui previously did. 

P.S. A minor improvement: always bring newly created tkinter windows to the front-most position for the user to see.
Issue: The new tkinter windows can be brought to the front when clicked on, but the main gui window will always stay behind all other newly created tkinter windows. 