### PR TITLE
Add pkg_resources.py2_warn to the other spec file of pyinstaller

### DIFF
--- a/pyinstaller_spec/empress_gui_app.spec
+++ b/pyinstaller_spec/empress_gui_app.spec
@@ -9,7 +9,9 @@ a = Analysis(['../empress_gui.py'],
              pathex=['pyinstaller_spec'],
              binaries=[],
              datas=[("../assets", "./assets")],
-             hiddenimports=[],
+             # pkg_resources.py2_warn hidden import needed if setuptools>=45.0.0
+             # https://github.com/pypa/setuptools/issues/1963#issuecomment-574265532
+             hiddenimports=['pkg_resources.py2_warn'],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],


### PR DESCRIPTION
Same as #150 . I forgot to add the hidden import to all spec files.