### PR TITLE
Pipfile to use pyinstaller with python.org bugfix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,9 @@ python_version = '3.7'
 biopython = '*'
 networkx = '*'
 pydot = '*'
+# Pyinstaller doesn't work with matplotlib 3.3.0
+# https://github.com/pyinstaller/pyinstaller/pull/5006
+# TODO: change to matplotlib = '*' after fix is released
 matplotlib = '==3.2.*'
 shapely = '*'
 numpy = '*'
@@ -17,4 +20,7 @@ numpy = '*'
 [dev-packages]
 coverage = '*'
 flake8 = "*"
-pyinstaller = "*"
+# Correctly locate macos python.org built-in tcl/tk
+# https://github.com/pyinstaller/pyinstaller/pull/5010
+# TODO: change to pyinstaller = '*' after fix is released
+pyinstaller = {git = "https://github.com/ssantichaivekin/pyinstaller.git", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "62492ec99f372418fdb57aa165e5e71ffede424df9d542660a7e16162f89a37e"
+            "sha256": "b38c74f18a8a6f14facc3f0d56b2b499b21f9af8d67ea7a1cc7d55156d17d4d0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -152,7 +152,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -160,7 +160,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.1"
         },
         "shapely": {
@@ -193,7 +193,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         }
     },
@@ -266,6 +266,7 @@
                 "sha256:0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432",
                 "sha256:c500f02867515e6c60a27875b408920d18332ddf96b4035ef03beddd782d4281"
             ],
+            "markers": "sys_platform == 'darwin' and sys_platform == 'darwin'",
             "version": "==1.14"
         },
         "mccabe": {
@@ -292,11 +293,9 @@
             "version": "==2.2.0"
         },
         "pyinstaller": {
-            "hashes": [
-                "sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7"
-            ],
-            "index": "pypi",
-            "version": "==3.6"
+            "editable": true,
+            "git": "https://github.com/ssantichaivekin/pyinstaller.git",
+            "ref": "efa95cb8b271295ba4f38f36474315e41de1d317"
         },
         "zipp": {
             "hashes": [


### PR DESCRIPTION
Update Pipfile to use pyinstaller with bugfix for tcl/tk that comes with macOS python.org python distribution.

This allows Pyinstaller to package python.org built-in tcl/tk. Tested on macOS Catalina 10.15.5.

See https://github.com/pyinstaller/pyinstaller/pull/5010 .