### PR TITLE
Add "All Files" to gui filedialog choices

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -344,7 +344,7 @@ class App(tk.Frame):
             self.load_files_var.set("Load files")
             # initialdir is set to be the current working directory
             input_file = filedialog.askopenfilename(initialdir=os.getcwd(), title="Select a host file",
-                                                       filetypes=[("Newick Trees", "*.nwk *.newick *.tree")])
+                                                       filetypes=[("Newick Trees", "*.nwk *.newick *.tree"), ("All Files", "*")])
             if input_file != "":
                 try:
                     self.recon_input.read_host(input_file)
@@ -364,7 +364,7 @@ class App(tk.Frame):
             self.load_files_var.set("Load files")
             # initialdir is set to be the same as that of the host file chosen by the user
             input_file = filedialog.askopenfilename(initialdir=pathlib.Path(self.host_file_path).parent, title="Select a parasite file",
-                                                       filetypes=[("Newick Trees", "*.nwk *.newick *.tree")])
+                                                       filetypes=[("Newick Trees", "*.nwk *.newick *.tree"), ("All Files", "*")])
             if input_file != "":
                 try:
                     self.recon_input.read_parasite(input_file)
@@ -381,7 +381,7 @@ class App(tk.Frame):
             self.load_files_var.set("Load files")
             # initialdir is set to be the same as that of the host file chosen by the user
             input_file = filedialog.askopenfilename(initialdir=pathlib.Path(self.host_file_path).parent, title="Select a mapping file",
-                                                       filetypes=[("Tip mapping", "*.mapping")])
+                                                       filetypes=[("Tip mapping", "*.mapping"), ("All Files", "*")])
             if input_file != "":
                 try:
                     self.recon_input.read_mapping(input_file)


### PR DESCRIPTION
Add "All Files" to filedialog choices for choosing host/parasite/mapping. This allows user to select the files in case their extensions does not match that of empress (`.tree .nwk .newick .mapping`).

Tested on Ubuntu 20.24.

<img width="400" alt="Screen Shot 2020-07-19 at 4 56 33 PM" src="https://user-images.githubusercontent.com/19219105/87888291-e92b2e80-c9e0-11ea-9117-b191a45b331a.png"> <img width="400" alt="Screen Shot 2020-07-19 at 4 56 40 PM" src="https://user-images.githubusercontent.com/19219105/87888294-ea5c5b80-c9e0-11ea-8932-5ca8417ce767.png">


Does not work on macOS Catalina 10.15.5 with python 3.7.6 installed from python.org with built in tcl/tk 8.6.8. The filters were grayed out and I could not select the filter options. Probably either a macOS bug or a tcl/tk bug. There is an issue similar to this on stackoverflow: https://stackoverflow.com/questions/58799432/macos-tkinter-how-does-filetypes-of-askopenfilename-work

Resolves #137 .