### PR TITLE
Remove second temporal constraint for a transfer event

### DIFF
--- a/empress/recon_vis/utils.py
+++ b/empress/recon_vis/utils.py
@@ -294,9 +294,6 @@ def build_temporal_graph(host_dict: dict, parasite_dict: dict, reconciliation: d
             right_child_parasite, right_child_host = right_child_mapping
             # since a transfer event is horizontal, we have these two implied relations
             temporal_graph[(parent[right_child_host], TreeType.HOST)].append((parasite, TreeType.PARASITE))
-            # the second relation is only added if the right child mapping is not a leaf mapping
-            if right_child_mapping not in reconciliation or reconciliation[right_child_mapping][0][0]!='C':
-                temporal_graph[(right_child_parasite, TreeType.PARASITE)].append((host, TreeType.HOST))
 
     for node_tuple in temporal_graph:
         # we need to make sure the associated value in the dictionary does not contain repeated node tuples


### PR DESCRIPTION
In `utils.py` `build_temporal_graph` remove the second temporal constraint for a transfer event. This makes the criteria for strong temporal consistency less strict. The criteria for weak temporal consistency remains the same.

<img width="556" alt="Screen Shot 2020-07-20 at 5 32 39 PM" src="https://user-images.githubusercontent.com/19219105/87999256-1ba35d00-caaf-11ea-88ee-4e5caa113a5f.png">

Tested by running `test_render_with_frequency_1` (it's the test that produces the image on the left) multiple times and see that it's producing strongly consistent reconciliations.