### PR TITLE
remove the display optional argument from CLI cost-regions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,8 +102,6 @@ Note: value in parenthesis denotes default value, asterisk denotes boolean flags
 * `-th` : Transfer high value (5)
 * `--outfile` : Name of output file. Must end in .pdf ("")
 * `--log` : Set graph to log scale*
-* `--display` : Display graph to screen*
-
 
 For example, the following example runs Costscape with duplication low value of 0.5, duplication high value of 10, transfer low value of 0.5, 
 and transfer high value of 10, that saves to a file called `foo.pdf` display it in log scale.

--- a/cli_commands/cost_regions.py
+++ b/cli_commands/cost_regions.py
@@ -20,9 +20,6 @@ def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
                                      help="name of output file, ending with .pdf")
     cost_regions_parser.add_argument("--log", action="store_true",
                                      help="set display to log scale")
-    cost_regions_parser.add_argument("--display", action="store_true",
-                                     help="display output on screen")
-
 
 def run_cost_regions(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -2,7 +2,6 @@
 Wraps empress functionalities
 """
 from typing import Dict
-import matplotlib
 import sys
 
 from matplotlib import pyplot as plt

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -4,13 +4,7 @@ Wraps empress functionalities
 from typing import Dict
 import matplotlib
 import sys
-# the tkagg backend is for pop-up windows, and will not work in environments
-# without graphics such as a remote server. Refer to issue #49
-try:
-    matplotlib.use("tkagg")
-except ImportError:
-    print("Using Agg backend: will not be able to create pop-up windows.", file=sys.stderr)
-    matplotlib.use("Agg")
+
 from matplotlib import pyplot as plt
 from typing import List, Tuple
 from abc import ABC, abstractmethod

--- a/empress/xscape/costscape.py
+++ b/empress/xscape/costscape.py
@@ -27,6 +27,6 @@ def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
     print("Elapsed time %.2f seconds" % elapsedTime)
     plotcosts.plotcosts(CVlist, transferMin, transferMax, dupMin, dupMax, \
                         optional.outfile, \
-                        optional.log, False)
+                        optional.log)
     if optional.outfile != "":
         print("Output written to file: ", optional.outfile)

--- a/empress/xscape/costscape.py
+++ b/empress/xscape/costscape.py
@@ -17,10 +17,6 @@ def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
     hostTree = newick_data.host_dict
     parasiteTree = newick_data.parasite_dict
     tip_mapping = newick_data.tip_mapping
-    if optional.outfile == "":
-        display = True
-    else:
-        display = optional.display
 
     print("Reconciling trees...")
     startTime = time.time()
@@ -31,6 +27,6 @@ def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
     print("Elapsed time %.2f seconds" % elapsedTime)
     plotcosts.plotcosts(CVlist, transferMin, transferMax, dupMin, dupMax, \
                         optional.outfile, \
-                        optional.log, display)
+                        optional.log, False)
     if optional.outfile != "":
         print("Output written to file: ", optional.outfile)

--- a/empress/xscape/plotcosts_analytic.py
+++ b/empress/xscape/plotcosts_analytic.py
@@ -113,11 +113,9 @@ def plot_costs_on_axis(axes: Axes, cost_vectors, transfer_min, transfer_max, dup
         axes.set_title("Costscape: %s" % title)
 
 def plotcosts(CVlist, transfer_min, transfer_max, dup_min, dup_max, outfile,
-              log=True, display=False, verbose=False):
+              log=True, verbose=False):
     figure, ax = plt.subplots(1, 1)
     plot_costs_on_axis(ax, CVlist, transfer_min, transfer_max, dup_min, dup_max,
                        outfile, log, verbose)
     if outfile != "":
         plt.savefig(outfile, format="pdf")
-    if display:
-        plt.show()

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -6,10 +6,6 @@
 
 import argparse
 
-import matplotlib
-# use agg backend, see # https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
-matplotlib.use("agg")
-
 import cli_commands.cluster
 import cli_commands.cost_regions
 import cli_commands.histogram

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -6,6 +6,10 @@
 
 import argparse
 
+import matplotlib
+# use agg backend, see # https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
+matplotlib.use("agg")
+
 import cli_commands.cluster
 import cli_commands.cost_regions
 import cli_commands.histogram

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -9,7 +9,10 @@ import os
 import sys
 import pathlib
 
-import matplotlib.pyplot as plt
+import matplotlib
+# use tkinter backend, see # https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
+matplotlib.use("tkagg")
+from matplotlib import pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 
 import empress

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -10,8 +10,6 @@ import sys
 import pathlib
 
 import matplotlib
-# use tkinter backend, required for embedding in Tk canvas
-# see https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -10,8 +10,8 @@ import sys
 import pathlib
 
 import matplotlib
-# use tkinter backend, see # https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
-matplotlib.use("tkagg")
+# use tkinter backend, required for embedding in Tk canvas
+# see https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -9,7 +9,6 @@ import os
 import sys
 import pathlib
 
-import matplotlib
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 


### PR DESCRIPTION
We remove ``--display`` from the optional arguments of the ``cost-regions`` command of the command-line interface. The command-line interface should not display a pop-up menu. The user can use the GUI if he/she wants a pop-up.

The reason we set the matplotlib backend was that we want the pop-up to work correctly on the command-line interface. Now that we don't display a pop-up anymore, we can remove that line.