### PR TITLE
GUI: fix the bug about the cluster window & the p-value histogram button 

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -582,13 +582,17 @@ class App(tk.Frame):
         if self.dup_cost is not None and self.trans_cost is not None and self.loss_cost is not None:
             # Enable the next button
             self.compute_reconciliations_btn.configure(state=tk.NORMAL)
-            self.disable_unaccessable_widgets()
             self.close_unnecessary_windows_if_opened()
         else:
             self.compute_reconciliations_btn.configure(state=tk.DISABLED)
 
     def display_recon_information(self):
         """Display numeric reconciliation results and close unnecessary windows."""
+        self.master.focus()  # remove focus from Entry and thus stop its validate command
+        self.close_unnecessary_windows_if_opened()
+        self.view_solution_space_dropdown.configure(state=tk.NORMAL)
+        self.view_reconciliations_dropdown.configure(state=tk.NORMAL)
+        self.view_pvalue_histogram_btn.configure(state=tk.NORMAL)
         App.recon_graph = self.recon_input.reconcile(self.dup_cost, self.trans_cost, self.loss_cost)
         self.recon_count = App.recon_graph.n_recon
         self.cospec_count, self.dup_count, self.trans_count, self.loss_count = App.recon_graph.median().count_events()
@@ -631,11 +635,6 @@ class App(tk.Frame):
             self.loss_count_label.destroy()
             self.loss_count_label = tk.Label(self.recon_nums_frame, text=self.loss_count)
             self.loss_count_label.grid(row=4, column=1, sticky="w")
-
-        self.close_unnecessary_windows_if_opened()
-        self.view_solution_space_dropdown.configure(state=tk.NORMAL)
-        self.view_reconciliations_dropdown.configure(state=tk.NORMAL)
-        self.view_pvalue_histogram_btn.configure(state=tk.NORMAL)
 
     def select_from_view_solution_space_dropdown(self, event):
         """When "View solution space" dropdown is clicked."""


### PR DESCRIPTION
Resolves #180 
This bug occurs to all data, including small data too. 
This pull request addresses the bug discovered by Prof Ran during testing:
"When I want to cluster data, sometimes I have to click on the cluster option a few times before the "Set the number of clusters" windows opens. In particular, I tried this on the vidua data. I set duplication cost to 1.0, transfer to 1.5, and loss to 1.0. Then, I clicked "Compute reconcilations". Then, I went to "View solution space" and had to click on "Clusters" several times before the "Number of clusters" window would open. Moreover, the p-value histogram button is grayed out and I can't activate it in this case. Vidua is the the Finches data."

Both issues were addressed and tested using the Finches data. The cluster window will pop up on the first time of clicking on "Number of clusters" and the p-value histogram button will not be grayed out in this case. However, another change is that when the user changes dtl costs in the Entry widgets, the self.view_solution_space_dropdown, self.view_reconciliations_dropdown, and self.view_pvalue_histogram_btn will no longer be disabled automatically. They will remain accessible and the results associated with them will be updated once the user clicks on "Compute reconciliations". 