### PR TITLE
Recreate matplotlib toolbar after redraw reconciliations

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -871,8 +871,8 @@ class ReconciliationsOneMPRWindow(tk.Frame):
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         # The toolbar allows the user to zoom in/out, drag the graph and save the graph
-        toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
-        toolbar.update()
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
+        self.toolbar.update()
         self.canvas.get_tk_widget().pack(side=tk.TOP)
 
     def create_checkboxes(self):
@@ -892,6 +892,7 @@ class ReconciliationsOneMPRWindow(tk.Frame):
 
     def update_one_mpr(self):
         self.canvas.get_tk_widget().destroy()
+        self.toolbar.destroy()
         self.one_mpr_fig = App.recon_graph.median().draw(
             show_internal_labels=self.show_internal_node_names_boolean.get(),
             show_freq=self.show_event_frequencies_boolean.get()
@@ -899,6 +900,9 @@ class ReconciliationsOneMPRWindow(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.one_mpr_fig, self.frame)
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        # Recreate the toolbar
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
+        self.toolbar.update()
 
 # View reconciliations - One per cluster
 class ReconciliationsOnePerClusterWindow(tk.Frame):
@@ -941,12 +945,13 @@ class ReconciliationsOnePerClusterWindow(tk.Frame):
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         # The toolbar allows the user to zoom in/out, drag the graph and save the graph
-        toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
-        toolbar.update()
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
+        self.toolbar.update()
         self.canvas.get_tk_widget().pack(side=tk.TOP)
 
     def update_median_recons(self):
         self.canvas.get_tk_widget().destroy()
+        self.toolbar.destroy()
         self.recon_solution_fig = self.recon_solution.draw(
             show_internal_labels=self.show_internal_node_names_boolean.get(),
             show_freq=self.show_event_frequencies_boolean.get()
@@ -954,6 +959,9 @@ class ReconciliationsOnePerClusterWindow(tk.Frame):
         self.canvas = FigureCanvasTkAgg(self.recon_solution_fig, self.frame)
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        # Recreate the toolbar
+        toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
+        toolbar.update()
 
 # p-value Histogram
 class PValueHistogramWindow(tk.Frame):


### PR DESCRIPTION
Recreate matplotlib toolbar (for moving, zooming, saving figure, etc) when user clicks `Display internal node names` or `Display frequencies`. This allows the toolbar buttons to work correctly after the user clicks `Display internal node names` or `Display frequencies`.

Previously, the toolbar did not get recreated, so the toolbar was still linking to the figure that was already destroyed, which is why using the save button on the toolbar saved the outdated figure.

Resolves #141

Now, I can move things after unchecking the boxes!
<img width="599" alt="Screen Shot 2020-07-23 at 1 09 46 PM" src="https://user-images.githubusercontent.com/19219105/88333953-dddc4980-cce5-11ea-94ce-cd94629b3d1d.png">
