### PR TITLE
GUI: fix the updating num_cluster bug

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -694,7 +694,7 @@ class App(tk.Frame):
         self.num_cluster_entry_box = CustomEntry(self.set_num_cluster_frame, width=3, textvariable=self.num_cluster_input)
         self.num_cluster_entry_box.set_border_color("green")
         self.num_cluster_entry_box.validate(validate="key", validatecommand=num_cluster_vcmd)
-        self.validate_num_cluster_input(1)
+        self.validate_num_cluster_input(self.num_cluster_entry_box.get())
         self.num_cluster_label.grid(row=0, column=0, sticky="e")
         self.num_cluster_entry_box.grid(row=0, column=1, sticky="w")
         self.num_cluster_error.grid(row=0, column=2)


### PR DESCRIPTION
Resolves #182.
The problem was that when creating the self.set_num_cluster_window, I shouldn't have validated self.num_cluster_input=1 by default every time, and should instead use self.num_cluster_entry_box.get() to get the current value in the entry field and validate that number. This also works if the user don't change the default value in the entry field since self.num_cluster_input was initialized to be 1 and the number in the entry field is 1 to start with. 