### PR TITLE
GUI: Change clustering to use n-splits

### DIFF
--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -23,6 +23,8 @@ from empress.cluster import cluster_util
 from empress.recon_vis import recon_viewer
 from empress.recon_vis import tanglegram
 
+CLUSTER_NSPLITS = 16
+
 def _find_roots(old_recon_graph) -> list:
     not_roots = set()
     for mapping in old_recon_graph:
@@ -188,8 +190,12 @@ class ReconGraphWrapper(Drawable):
             cluster_util.get_tree_info(self.recon_input, self.dup_cost, self.trans_cost, self.loss_cost)
 
         score = cluster_util.mk_pdv_score(host_tree, parasite_tree, parasite_root)
+        n_splits = CLUSTER_NSPLITS
+        # If the user asks for more clusters, we need to find at least that many splits
+        if n_splits < n:
+            n_splits = n
 
-        graphs, scores, _ = cluster_util.cluster_graph(self.recongraph, parasite_root, score, 4, n)
+        graphs, scores, _ = cluster_util.cluster_graph_n(self.recongraph, parasite_root, score, n_splits, mpr_count, n)
         new_graphs = []
         for graph in graphs:
             roots = _find_roots(graph)

--- a/empress/cluster/cluster_util.py
+++ b/empress/cluster/cluster_util.py
@@ -148,7 +148,7 @@ def full_split_n(g, gene_root, n, mpr_count):
         elif len(gs) == mpr_count:
             break
         depth += 1
-    print(("Depth: {}".format(depth)))
+    #print(("Depth: {}".format(depth)))
     return gs
 
 def full_split(g, gene_root, depth):


### PR DESCRIPTION
Previously, clustering used depth with a default of 4. Now it uses
n-splits with a default of 16, set by a variable. The primary result of
this change is that the user will never get fewer clusters than
requested. It may either improve or degrade the clustering quality in
different cases.