### PR TITLE
CLI: Add p-value histogram

### DIFF
--- a/.github/workflows/run-tests-and-draw-examples.yml
+++ b/.github/workflows/run-tests-and-draw-examples.yml
@@ -49,6 +49,9 @@ jobs:
     - name: Run cluster example in Readme.md
       run: |
         pipenv run python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping 3 --median --n-splits 4 --support
+    - name: Run p-value example in Readme.md
+      run: |
+        pipenv run python empress_cli.py p-value examples/heliconius_host.nwk examples/heliconius_parasite.nwk examples/heliconius_mapping.mapping -d 4 -t 2 -l 1
     - name: Run draw examples for empress wrapper
       run: |
         pipenv run python -m draw.draw_empress_wrapper

--- a/Readme.md
+++ b/Readme.md
@@ -114,7 +114,7 @@ $ python empress_cli.py cost-regions examples/heliconius_host.nwk examples/helic
 ### DTL Reconciliation
 * `-d` : Duplication cost (2)
 * `-t` : Transfer cost (3)
-* `-l` : Lost cost (1)
+* `-l` : Loss cost (1)
 
 For example, to run DTL Reconciliation with duplication cost of 4, transfer cost of 2 and lost cost of 1, you run
 ```bash
@@ -125,7 +125,7 @@ $ python empress_cli.py reconcile examples/heliconius_host.nwk examples/heliconi
 ### Pairwise Distance Histogram
 * `-d` : Duplication cost (2)
 * `-t` : Transfer cost (3)
-* `-l` : Lost cost (1)
+* `-l` : Loss cost (1)
 * `--histogram` : Name of output file. If no filename is provided, outputs to a filename based on the input tree data file
 * `--xnorm` : Normalize the x-axis so that the distances range between 0 and 1*
 * `--ynorm` : Normalize the y-axis so that the distances range between 0 and 1*
@@ -144,7 +144,7 @@ $ python empress_cli.py histogram examples/heliconius_host.nwk examples/heliconi
 ### Clustering
 * `-d` : Duplication cost (2)
 * `-t` : Transfer cost (3)
-* `-l` : Lost cost (1)
+* `-l` : Loss cost (1)
 * `--median` : Print out medians of each cluster
 * `--depth` : How far down to split the graph before clustering
 * `--n-splits` : As an alternative to passing the depth directly, split the reconciliation graph into at least n distinct pieces before merging
@@ -158,3 +158,11 @@ For example, to find at least 8 distinct parts of reconciliation-space before me
 $ python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
                                 examples/heliconius_mapping.mapping 3 --median --n-splits 8 --support
 ```
+
+### P-Value Histogram
+* `-d` : Duplication cost (2)
+* `-t` : Transfer cost (3)
+* `-l` : Loss cost (1)
+* `--filename` : The desired filename for the output graph*
+
+This tests the hypothesis that the optimal cost was obtained by a random tip mapping by sampling random tip mappings and checking the cost. The output is a histogram that shows the distribution of scores from random mappings, the score from the known mapping, and the p-value.

--- a/Readme.md
+++ b/Readme.md
@@ -163,6 +163,10 @@ $ python empress_cli.py cluster examples/heliconius_host.nwk examples/heliconius
 * `-d` : Duplication cost (2)
 * `-t` : Transfer cost (3)
 * `-l` : Loss cost (1)
-* `--filename` : The desired filename for the output graph*
+* `--outfile` : The desired filename for the output graph
 
 This tests the hypothesis that the optimal cost was obtained by a random tip mapping by sampling random tip mappings and checking the cost. The output is a histogram that shows the distribution of scores from random mappings, the score from the known mapping, and the p-value.
+```bash
+$ python empress_cli.py p-value examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
+                                examples/heliconius_mapping.mapping -d 4 -t 2 -l 1
+```

--- a/cli_commands/p_value.py
+++ b/cli_commands/p_value.py
@@ -16,11 +16,11 @@ def run_p_value(args):
     cost_suffix = ".pvalue.{}-{}-{}".format(args.dup_cost, args.loss_cost, args.trans_cost)
     if args.outfile is None:
         host_filepath = Path(args.host)
-        out_filepath = host_filepath.with_suffix(cost_suffix + ".pdf")
+        outfile = host_filepath.with_suffix(cost_suffix + ".pdf")
     else:
-        out_filepath = args.filename
+        outfile = args.outfile
     ax = plt.gca()
     recongraph = recon_input.reconcile(args.dup_cost, args.trans_cost, args.loss_cost)
     recongraph.draw_stats_on(ax)
-    plt.savefig(out_filepath)
+    plt.savefig(outfile)
     plt.close()

--- a/cli_commands/p_value.py
+++ b/cli_commands/p_value.py
@@ -1,0 +1,26 @@
+import argparse
+from pathlib import Path
+from matplotlib import pyplot as plt
+import cli_commands._shared_utils
+import empress
+
+def add_p_value_to_parser(p_value_parser: argparse.ArgumentParser):
+    cli_commands._shared_utils.add_recon_input_args_to_parser(p_value_parser)
+    cli_commands._shared_utils.add_dtl_costs_to_parser(p_value_parser)
+    p_value_parser.add_argument("--filename", metavar="<filename>",
+                                help="Output the p-value test at the path provided. If no filename is "
+                                "provided, outputs to a filename based on the input host file.")
+
+def run_p_value(args):
+    recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
+    cost_suffix = ".pvalue.{}-{}-{}".format(args.dup_cost, args.loss_cost, args.trans_cost)
+    if args.filename is None:
+        fname = Path(args.host)
+        f = str(fname.with_suffix(cost_suffix + ".pdf"))
+    else:
+        f = args.filename
+    ax = plt.gca()
+    g = recon_input.reconcile(args.dup_cost, args.trans_cost, args.loss_cost)
+    g.draw_stats_on(ax)
+    plt.savefig(f)
+    plt.clf()

--- a/cli_commands/p_value.py
+++ b/cli_commands/p_value.py
@@ -7,20 +7,20 @@ import empress
 def add_p_value_to_parser(p_value_parser: argparse.ArgumentParser):
     cli_commands._shared_utils.add_recon_input_args_to_parser(p_value_parser)
     cli_commands._shared_utils.add_dtl_costs_to_parser(p_value_parser)
-    p_value_parser.add_argument("--filename", metavar="<filename>",
+    p_value_parser.add_argument("--outfile", metavar="<filename>",
                                 help="Output the p-value test at the path provided. If no filename is "
                                 "provided, outputs to a filename based on the input host file.")
 
 def run_p_value(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
     cost_suffix = ".pvalue.{}-{}-{}".format(args.dup_cost, args.loss_cost, args.trans_cost)
-    if args.filename is None:
-        fname = Path(args.host)
-        f = str(fname.with_suffix(cost_suffix + ".pdf"))
+    if args.outfile is None:
+        host_filepath = Path(args.host)
+        out_filepath = host_filepath.with_suffix(cost_suffix + ".pdf")
     else:
-        f = args.filename
+        out_filepath = args.filename
     ax = plt.gca()
-    g = recon_input.reconcile(args.dup_cost, args.trans_cost, args.loss_cost)
-    g.draw_stats_on(ax)
-    plt.savefig(f)
-    plt.clf()
+    recongraph = recon_input.reconcile(args.dup_cost, args.trans_cost, args.loss_cost)
+    recongraph.draw_stats_on(ax)
+    plt.savefig(out_filepath)
+    plt.close()

--- a/empress_cli.py
+++ b/empress_cli.py
@@ -10,7 +10,7 @@ import cli_commands.cluster
 import cli_commands.cost_regions
 import cli_commands.histogram
 import cli_commands.reconcile
-
+import cli_commands.p_value
 
 def main():
     parser = argparse.ArgumentParser(
@@ -21,6 +21,7 @@ def main():
     # Create subparsers and setup the subparsers
     subparsers = parser.add_subparsers(dest='command', help='Commands empress can run', required=True)
 
+    # Cost Regions
     cost_regions_description = "Find cost regions that give same maximum parsimony reconciliations."
     cost_regions_parser = subparsers.add_parser(
         'cost-regions', description=cost_regions_description, help=cost_regions_description.lower().rstrip('.'),
@@ -28,6 +29,7 @@ def main():
     )
     cli_commands.cost_regions.add_cost_regions_to_parser(cost_regions_parser)
 
+    # Reconcile
     reconcile_description = "Find maximum parsimony reconciliations given duplication, transfer, and loss costs."
     reconcile_parser = subparsers.add_parser(
         'reconcile', description=reconcile_description, help=reconcile_description.lower().rstrip('.'),
@@ -35,6 +37,7 @@ def main():
     )
     cli_commands.reconcile.add_reconcile_to_parser(reconcile_parser)
 
+    # Histogram
     histogram_description = "Find pairwise distance histogram of all reconciliations given duplication, transfer, " \
                             "and loss costs."
     histogram_parser = subparsers.add_parser(
@@ -43,13 +46,23 @@ def main():
     )
     cli_commands.histogram.add_histogram_to_parser(histogram_parser)
 
+    # Cluster
     cluster_description = "Find cluster of reconciliations with similar properties given duplication, transfer, " \
-                          "and loss costs. "
+                          "and loss costs."
     cluster_parser = subparsers.add_parser(
         'cluster', description=cluster_description, help=cluster_description.lower().rstrip('.'),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # prints default values
     )
     cli_commands.cluster.add_cluster_to_parser(cluster_parser)
+
+    # P Value
+    p_value_description = "Test the hypothesis that the optimal reconciliation cost was obtained using " \
+                          "a random mapping."
+    p_value_parser = subparsers.add_parser(
+            'p-value', description=p_value_description, help=p_value_description.lower().rstrip("."),
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    cli_commands.p_value.add_p_value_to_parser(p_value_parser)
 
     # Determine which command we should run and run it
     args = parser.parse_args()
@@ -62,6 +75,8 @@ def main():
         cli_commands.histogram.run_histogram(args)
     elif args.command == "cluster":
         cli_commands.cluster.run_cluster(args)
+    elif args.command == "p-value":
+        cli_commands.p_value.run_p_value(args)
 
 
 if __name__ == "__main__":

--- a/test/integration/run_cli_command_combinations.py
+++ b/test/integration/run_cli_command_combinations.py
@@ -14,6 +14,7 @@ options_for_histogram = ["-d", "-t", "-l", "--histogram", "--xnorm", "--ynorm", 
                          "--csv", "--stats", "--time"]
 options_for_cluster = ["-d", "-t", "-l", "--medians", "--depth", "--n-splits", "--pdv-vis", "--support-vis",
                        "--pdv", "--support"]
+options_for_pvalue = ["-d", "-t", "-l", "--outfile"]
 
 # copied from https://docs.python.org/3/library/itertools.html#itertools-recipes
 def powerset(iterable):
@@ -36,7 +37,7 @@ def input_value(option):
     elif option == "--histogram":
         return "test_cli_output_histogram.pdf"
     elif option == "--outfile":
-        return "test_cli_output_cost_regions.pdf"
+        return "test_cli_output_outfile.pdf"
     elif option in ["--depth", "--n-splits"]:
         return "2"
     else:
@@ -60,6 +61,8 @@ def run_command(command: str, n_tests: int, fail_fast=True):
     elif command == "cluster":
         options_for_command = options_for_cluster
         num_clusters = "3"
+    elif command == "p-value":
+        options_for_command = options_for_pvalue
     else:
         raise RuntimeError("command [%s] not recognized" % command)
 
@@ -119,3 +122,4 @@ if __name__ == '__main__':
     run_command("reconcile", args.tests_per_group)
     run_command("histogram", args.tests_per_group)
     run_command("cluster", args.tests_per_group)
+    run_command("p-value", args.tests_per_group)


### PR DESCRIPTION
Adds the option of creating a p-value histogram to the CLI.
```bash
# draws to ./examples/heliconius_host.pvalue.4.0-1.0-2.0.pdf (same as host directory)
$ python empress_cli.py p-value examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
                                examples/heliconius_mapping.mapping -d 4 -t 2 -l 1

# draws to ./pvalue_graph.pdf
$ python empress_cli.py p-value examples/heliconius_host.nwk examples/heliconius_parasite.nwk \
                                examples/heliconius_mapping.mapping -d 4 -t 2 -l 1 --outfile pvalue_graph.pdf
```