### PR TITLE
Solves histogram division by zero and width warning bug

### DIFF
--- a/empress/histogram/histogram_main.py
+++ b/empress/histogram/histogram_main.py
@@ -65,9 +65,17 @@ def transform_hist(hist, omit_zeros, xnorm, ynorm, cumulative):
         hist_zero = histogram_display.omit_zeros(hist)
     else:
         hist_zero = hist
+    # Omitting zeros can cause the histogram to become empty - can just return
+    # early without normalization. Other functions assume histogram is nonempty.
+    if len(hist_zero) == 0:
+        return hist_zero, 1
     # Normalize the x values
     if xnorm:
-        width = 1 / float(max(hist_zero.keys()))
+        denominator = float(max(hist_zero.keys()))
+        # The zero column should factor into the width if it exists
+        if not omit_zeros:
+            denominator += 1
+        width = 1 / denominator
         hist_xnorm = histogram_display.normalize_xvals(hist_zero)
     else:
         width = 1


### PR DESCRIPTION
Omitting zeros can cause the histogram to become empty. This change took care of that.

Resolves #185 . Resolves #186