### PR TITLE
Default output location for cost-regions

### DIFF
--- a/cli_commands/cost_regions.py
+++ b/cli_commands/cost_regions.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 
 import empress
 from empress.xscape import costscape
@@ -16,12 +17,17 @@ def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
                                      type=float, help="transfer low value for cost regions viewer window")
     cost_regions_parser.add_argument("-th", "--transfer-high", metavar="<transfer_high>", default=5,
                                      type=float, help="transfer high value for cost regions viewer window")
-    cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default="",
+    cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default=None, required=True,
                                      help="name of output file, ending with .pdf")
     cost_regions_parser.add_argument("--log", action="store_true",
                                      help="set display to log scale")
 
 def run_cost_regions(args):
     recon_input = empress.ReconInputWrapper.from_files(args.host, args.parasite, args.mapping)
+    if args.outfile is None:
+        host_filepath = Path(args.host)
+        outfile = host_filepath.with_suffix(".cost-regions.pdf")
+    else:
+        outfile = args.outfile
     costscape.solve(recon_input, args.duplication_low, args.duplication_high, args.transfer_low, args.transfer_high,
-                    args)
+                    outfile, args.log)

--- a/cli_commands/cost_regions.py
+++ b/cli_commands/cost_regions.py
@@ -17,7 +17,7 @@ def add_cost_regions_to_parser(cost_regions_parser: argparse.ArgumentParser):
                                      type=float, help="transfer low value for cost regions viewer window")
     cost_regions_parser.add_argument("-th", "--transfer-high", metavar="<transfer_high>", default=5,
                                      type=float, help="transfer high value for cost regions viewer window")
-    cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default=None, required=True,
+    cost_regions_parser.add_argument("--outfile", metavar="<output_file>", default=None,
                                      help="name of output file, ending with .pdf")
     cost_regions_parser.add_argument("--log", action="store_true",
                                      help="set display to log scale")

--- a/empress/xscape/costscape.py
+++ b/empress/xscape/costscape.py
@@ -12,7 +12,7 @@ from empress import xscape
 from empress.xscape import reconcile
 from empress.xscape import plotcosts_analytic as plotcosts
 
-def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
+def solve(newick_data, transferMin, transferMax, dupMin, dupMax, outfile, log):
     print("Costscape %s" % xscape.PROGRAM_VERSION_TEXT)
     hostTree = newick_data.host_dict
     parasiteTree = newick_data.parasite_dict
@@ -20,13 +20,12 @@ def solve(newick_data, transferMin, transferMax, dupMin, dupMax, optional):
 
     print("Reconciling trees...")
     startTime = time.time()
-    CVlist = reconcile.reconcile(parasiteTree, hostTree, tip_mapping, \
+    CVlist = reconcile.reconcile(parasiteTree, hostTree, tip_mapping,
                                  transferMin, transferMax, dupMin, dupMax)
     endTime = time.time()
-    elapsedTime = endTime- startTime
+    elapsedTime = endTime - startTime
     print("Elapsed time %.2f seconds" % elapsedTime)
-    plotcosts.plotcosts(CVlist, transferMin, transferMax, dupMin, dupMax, \
-                        optional.outfile, \
-                        optional.log)
-    if optional.outfile != "":
-        print("Output written to file: ", optional.outfile)
+    plotcosts.plotcosts(CVlist, transferMin, transferMax, dupMin, dupMax,
+                        outfile, log)
+    if outfile is not None:
+        print("Output written to: ", outfile)

--- a/empress/xscape/plotcosts_analytic.py
+++ b/empress/xscape/plotcosts_analytic.py
@@ -115,7 +115,11 @@ def plot_costs_on_axis(axes: Axes, cost_vectors, transfer_min, transfer_max, dup
 def plotcosts(CVlist, transfer_min, transfer_max, dup_min, dup_max, outfile,
               log=True, verbose=False):
     figure, ax = plt.subplots(1, 1)
+    if outfile is None:
+        title = ""
+    else:
+        title = outfile
     plot_costs_on_axis(ax, CVlist, transfer_min, transfer_max, dup_min, dup_max,
-                       outfile, log, verbose)
-    if outfile != "":
+                       title, log, verbose)
+    if outfile is not None:
         plt.savefig(outfile, format="pdf")


### PR DESCRIPTION
Previously, if `--outfile` is not specified in cost-regions, it will not write to any file. This change makes cost-regions write to the same location as the host file similar to other commands such as histogram and p-value.

Resolves #214 