### PR TITLE
[PART 1] GUI: Fix reconciliation button graying out bug

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -510,7 +510,8 @@ class App(tk.Frame):
         # self.trans_input is tk.DoubleVar(), initialized to be 1.00
         self.trans_entry_box = CustomEntry(self.costs_frame, width=4, textvariable=self.trans_input)
         self.trans_entry_box.set_border_color("green")
-        self.trans_entry_box.validate(validate="all", validatecommand=trans_vcmd)
+        self.trans_entry_box.validate(validate="key", validatecommand=trans_vcmd)
+        print(self.trans_entry_box.keys())
         self.trans_entry_box.grid(row=1, column=1, sticky="w")
         self.validate_trans_input(str(self.trans_entry_box.get()))  # validate for the initialization of self.trans_input to be 1.0
 
@@ -522,7 +523,7 @@ class App(tk.Frame):
         # self.loss_input is tk.DoubleVar(), initialized to be 1.00
         self.loss_entry_box = CustomEntry(self.costs_frame, width=4, textvariable=self.loss_input)
         self.loss_entry_box.set_border_color("green")
-        self.loss_entry_box.validate(validate="all", validatecommand=loss_vcmd)
+        self.loss_entry_box.validate(validate="key", validatecommand=loss_vcmd)
         self.loss_entry_box.grid(row=2, column=1, sticky="w")
         self.validate_loss_input(str(self.loss_entry_box.get()))  # validate for the initialization of self.loss_input to be 1.00
     


### PR DESCRIPTION
As documented in #180, sometimes `View reconciliations` and `View p-value histogram` buttons become unexpectedly grayed out after setting the transfer cost to 1.5,  clicking compute reconciliations, and then set the number of cluster.

This happens because our code says we will gray out the compute reconciliation button and other buttons when an action happens to the three cost boxes (duplication, transfer, loss). The problem with this is that when we click on `View solution space` -> `Clusters`, the event `focusout` and `focusin` are triggered by the input boxes, graying out the button. The fix is to have the gray out command run only on `key` event, which is triggered on text change.

Resolve #180 

Tested on macOS Catalina 10.15.5. I could not reproduce step five of the issue which says "Click on `View solution space` -> `Clusters` again. `View reconciliations` becomes available but `View p-value histogram` remains unavailable" after I made the changes even when I when changing the cost and clicking on clusters multiple times. I assume that it is also already fixed.