### PR TITLE
GUI: Fix toolbar error when changing reconciliation boolean options

### DIFF
--- a/empress_gui.py
+++ b/empress_gui.py
@@ -962,8 +962,8 @@ class ReconciliationsOnePerClusterWindow(tk.Frame):
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         # Recreate the toolbar
-        toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
-        toolbar.update()
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
+        self.toolbar.update()
 
 # p-value Histogram
 class PValueHistogramWindow(tk.Frame):


### PR DESCRIPTION
Problem: the matplotlib toolbar could not be deleted properly, so it raises an exception. This is because when we update the toolbar for the "one per reconciliation windows," it creates a new toolbar using the code
```python
toolbar = NavigationToolbar2Tk(self.canvas, self.frame)`
```
This toolbar variable disappears after the update function finishes. However, when we remove the toolbar, we call `self.toolbar.destroy()`.

Solution: tie the toolbar variable to self at creation
```python
self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)`
```

Tested on macOS Catalina 10.15.5, can check/uncheck boolean options in #223 correctly.

Resolves #223 