### PR TITLE
Support empty newick tree node names

### DIFF
--- a/empress/input_reader.py
+++ b/empress/input_reader.py
@@ -137,6 +137,7 @@ class _ReconInput:
         """
 
         tree = Phylo.read(StringIO(newick_string), "newick")
+        _ReconInput._name_unnamed_nodes(tree, tree_type)
         distance_dict = tree.depths(unit_branch_lengths=True)
         # Get the actual distance annotations (zero for unannotated trees)
         D = {}
@@ -153,6 +154,18 @@ class _ReconInput:
             name = clade.name
             real_distance_dict[name] = dist
         return tree_dict, real_distance_dict
+    
+    @staticmethod
+    def _name_unnamed_nodes(tree: Phylo.Newick.Tree, tree_type: str):
+        count = 0
+        for clade in tree.find_clades():
+            if clade.name is None:
+                if tree_type == "host":
+                    new_name = "_h{}".format(count)
+                else:
+                    new_name = "_p{}".format(count)
+                clade.name = new_name
+                count += 1
 
     @staticmethod
     def _build_tree(dfs_list):

--- a/examples/heliconius_host.nwk
+++ b/examples/heliconius_host.nwk
@@ -1,1 +1,1 @@
-((((aglaope_EastPE,amaryllis_EastPE)m4,(ecuadoriensis_EastE,malleti_EastE)m5)m3,((thelxiopeia_EastFG,melpomene_EastFG)m7,melpomene_EastT)m6)m2,(((melpomene_WestPA,rosina_WestCR)m10,rosina_WestPA)m9,(melpomene_EastC,cythera_WestE)m11)m8)m1;
+((((aglaope_EastPE,amaryllis_EastPE),(ecuadoriensis_EastE,malleti_EastE)),((thelxiopeia_EastFG,melpomene_EastFG),melpomene_EastT)),(((melpomene_WestPA,rosina_WestCR),rosina_WestPA),(melpomene_EastC,cythera_WestE)));


### PR DESCRIPTION
Automatically add node names to newick tree nodes with empty names.

The generated names for the host nodes are _h0, _h1, _h2, ...
The generated names for the parasite nodes are _p0, _p1, _p2, ...