### PR TITLE
Allow host tree and parasite tree to have the same node name

### DIFF
--- a/empress/recon_vis/tree.py
+++ b/empress/recon_vis/tree.py
@@ -3,9 +3,9 @@ tree.py
 Defines classes related to host and parasite nodes and trees
 """
 
-from enum import Enum
+from enum import IntEnum, Enum
 
-class TreeType(Enum):
+class TreeType(IntEnum):
     """ Defines type of the tree """
     HOST = 1
     PARASITE = 2

--- a/test/recon_vis/test_utils.py
+++ b/test/recon_vis/test_utils.py
@@ -316,6 +316,29 @@ class TestUtils(unittest.TestCase):
                             if ordering_dict is not None:
                                 self.check_topological_order(temporal_graph, ordering_dict)
                 count += 1
+    
+    def test_check_topological_order_with_host_and_parasite_same_node_names(self):
+        host = {
+            'hTop': ('Top', 'a', ('a', 'm1'), ('a', 'm2')),
+            ('a', 'm1'): ('a', 'm1', None, None),
+            ('a', 'm2'): ('a', 'm2', None, None)
+        }
+
+        parasite = {
+            'pTop': ('Top', 'a', ('a', 'n1'), ('a', 'n2')),
+            ('a', 'n1'): ('a', 'n1', None, None),
+            ('a', 'n2'): ('a', 'n2', None, None)
+        }
+
+        reconciliation = {
+            ('a', 'a'): [('S', ('n1', 'm1'), ('n2', 'm2'))], 
+            ('n1', 'm1'): [('C', (None, None), (None, None))], 
+            ('n2', 'm2'): [('C', (None, None), (None, None))]
+        }
+
+        temporal_graph = utils.build_temporal_graph(host, parasite, reconciliation)
+        ordering_dict = utils.topological_order(temporal_graph)
+        self.check_topological_order(temporal_graph, ordering_dict)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change allows host tree and parasite tree to have the same node name.

The topological order algorithm has a line that sort the set of vertices of both the host nodes and parasite nodes. This create an error if a host node and a parasite node has the same name. Host node and parasite node is a two-tuple `(name: str, nodetype: TreeType)` where `nodetype` is not comparable. When they have the same name, python tries to compare `nodetype` while sorting, leading to an error. Making `nodetype` comparable allows host tree and parasite tree to have the same node name.

Resolves #232