### PR TITLE
Force empress app to run in light mode on macOS

### DIFF
--- a/pyinstaller_spec/empress_gui_app.spec
+++ b/pyinstaller_spec/empress_gui_app.spec
@@ -48,5 +48,7 @@ app = BUNDLE(coll,
              info_plist={
                  'NSPrincipalClass': 'NSApplication',  # Enable retina display
                  'CFBundleName': 'Empress DTL Computational Biology Tool',  # Enable Siri
+                 # Forces macOS to open this app in light mode
+                 'NSRequiresAquaSystemAppearance': True,
              }
             )


### PR DESCRIPTION
The macOS empress executable does not display text correctly in dark mode due to its outdated tk version. This change tells macOS to run empress executable on light mode even if the user is using dark mode. Tested on macOS Big Sur 11.4 (20F71).

Empress app running in dark mode:
<img width="500" alt="macOS empress app in dark mode does not display text correctly" src="https://user-images.githubusercontent.com/19219105/120952249-da727500-c774-11eb-9b5f-7e4945e12bbe.png">
Empress app forced to run in light mode (all other apps are still in dark mode):
<img width="500" alt="macOS empress app forced to be on light mode" src="https://user-images.githubusercontent.com/19219105/120952597-9633a480-c775-11eb-9226-f5c4afee4ffd.png">



Although updating tk version might seem like a good idea, it introduces other bugs that are hard to fix such as #229.

The best workaround is to tell macOS to run empress executable on light mode even if the user is using dark mode. See [Apple's documentation on opting out of dark mode](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app#2993818).