### PR TITLE
GUI: Add font size to tanglegram and reconciliation window

### DIFF
--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -71,9 +71,17 @@ class Drawable(ABC):
 class ReconciliationWrapper(Drawable):
     # TODO: Replace dict with Reconciliation type
     # https://github.com/ssantichaivekin/eMPRess/issues/30
-    def __init__(self, reconciliation: dict, root: tuple, recon_input: _ReconInput, dup_cost, trans_cost, loss_cost,
-            total_cost: float, event_frequencies: Dict[tuple, float],
-            node_frequencies: Dict[tuple, float] = None):
+    def __init__(self,
+                 reconciliation: dict,
+                 root: tuple,
+                 recon_input: _ReconInput,
+                 dup_cost,
+                 trans_cost,
+                 loss_cost,
+                 total_cost: float,
+                 event_frequencies: Dict[tuple, float],
+                 node_frequencies: Dict[tuple, float] = None
+                 ):
         self.recon_input = recon_input
         self.dup_cost = dup_cost
         self.trans_cost = trans_cost
@@ -84,15 +92,22 @@ class ReconciliationWrapper(Drawable):
         self.event_frequencies = event_frequencies
         self.node_frequencies = node_frequencies
 
-    def draw(self, show_internal_labels: bool = False, show_freq: bool = True):
-        figure, ax = plt.subplots(1, 1)
-        self.draw_on(ax, show_internal_labels=show_internal_labels, show_freq=show_freq)
-        return figure
-
-    def draw_on(self, axes: plt.Axes, show_internal_labels: bool = False, show_freq: bool = True):
-        recon_viewer.render(self.recon_input.host_dict, self.recon_input.parasite_dict, self._reconciliation,
-                            self.event_frequencies, show_internal_labels=show_internal_labels, show_freq=show_freq,
-                            axes=axes)
+    def draw_on(self,
+                axes: plt.Axes,
+                show_internal_labels: bool = False,
+                show_freq: bool = True,
+                node_font_size: float = 0.3,
+                ):
+        recon_viewer.render(
+            self.recon_input.host_dict,
+            self.recon_input.parasite_dict,
+            self._reconciliation,
+            self.event_frequencies,
+            show_internal_labels=show_internal_labels,
+            show_freq=show_freq,
+            node_font_size=node_font_size,
+            axes=axes
+        )
 
     def count_events(self) -> Tuple[int, int, int, int]:
         """

--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -53,18 +53,18 @@ class Drawable(ABC):
     """
 
     @abstractmethod
-    def draw_on(self, axes: plt.Axes):
+    def draw_on(self, axes: plt.Axes, **kwargs):
         """
         Draw self on matplotlib Axes
         """
         pass
 
-    def draw(self) -> plt.Figure:
+    def draw(self, **kwargs) -> plt.Figure:
         """
         Draw self as matplotlib Figure.
         """
         figure, ax = plt.subplots(1, 1)
-        self.draw_on(ax)
+        self.draw_on(ax, **kwargs)
         return figure
 
 
@@ -249,11 +249,11 @@ class ReconInputWrapper(_ReconInput, Drawable):
     def __init__(self, *args, **kwargs):
         _ReconInput.__init__(self, *args, **kwargs)
 
-    def draw_on(self, ax: plt.Axes):
+    def draw_on(self, ax: plt.Axes, node_font_size=9):
         """
         This draws the tanglegram.
         """
-        tanglegram.render(self.host_dict, self.parasite_dict, self.tip_mapping, True, ax)
+        tanglegram.render(self.host_dict, self.parasite_dict, self.tip_mapping, True, ax, node_font_size=node_font_size)
 
     def compute_cost_regions(self, transfer_min: float, transfer_max: float,
                              dup_min: float, dup_max: float) -> CostRegionsWrapper:

--- a/empress/recon_vis/recon_viewer.py
+++ b/empress/recon_vis/recon_viewer.py
@@ -12,8 +12,16 @@ import matplotlib.pyplot as plt
 FONT_SIZE_STRETCH = 3.0     # Parameter used in _calculate_font_size
 SIGMOID_SCALE = 0.8         # Parameter used in _sigmoid
 
-def render(host_dict: dict, parasite_dict: dict, recon_dict: dict, event_frequencies: Dict[tuple, float] = None, show_internal_labels: bool = False, 
-           show_freq: bool = False, show_legend: bool = True, axes: Union[plt.Axes, None] = None):
+def render(host_dict: dict,
+           parasite_dict: dict,
+           recon_dict: dict,
+           event_frequencies: Dict[tuple, float] = None,
+           show_internal_labels: bool = False,
+           show_freq: bool = False,
+           show_legend: bool = True,
+           node_font_size: float = 0.3,
+           axes: Union[plt.Axes, None] = None,
+           ):
     """ Renders a reconciliation using matplotlib
     :param host_dict:  Host tree represented in dictionary format
     :param parasite_dict:  Parasite tree represented in dictionary format
@@ -36,9 +44,7 @@ def render(host_dict: dict, parasite_dict: dict, recon_dict: dict, event_frequen
     if show_legend:
         _create_legend(fig, consistency_type)
 
-    # Calculates font sizes
-    num_tip_nodes = len(host_tree.leaf_list()) + len(parasite_tree.leaf_list())
-    font_size = _calculate_font_size(num_tip_nodes)
+    font_size = node_font_size
 
     root = parasite_tree.root_node
     host_lookup = host_tree.name_to_node_dict()
@@ -371,25 +377,6 @@ def _get_frequency_text(frequency: float):
     :return a string that has the frequency as a percentage
     """
     return str(round(frequency * 100))
-
-
-def _calculate_font_size(num_tip_nodes: int):
-    """
-    Calculates the font_size
-    :param num_tip_nodes: Number of tip nodes in a tree
-    :return the font size for the tips and internal nodes of a tree
-    """
-    x = (render_settings.START_SIZE - num_tip_nodes) / render_settings.STEP_SIZE
-    return FONT_SIZE_STRETCH * _sigmoid(x)  # 3.0 is a magic value that can be adjusted
-
-
-def _sigmoid(x: float):
-    """
-    sigmoid Function
-    :param x: A number to be plugged into the function
-    :return a sigmoid value based on the input value, x
-    """
-    return (1 / (1 + math.e**(-SIGMOID_SCALE*x)))  # 0.8 is a magic value that can be adjusted
 
 
 def _render_parasite_branches(fig: plot_tools.FigureWrapper,  node: tree.Node, recon_obj: recon.Reconciliation, host_lookup: dict, parasite_lookup: dict):

--- a/empress/recon_vis/tanglegram.py
+++ b/empress/recon_vis/tanglegram.py
@@ -12,14 +12,19 @@ VERTICAL_OFFSET = 20
 HORIZONTAL_SPACING = 10
 LEAF_SPACING = 5
 EXTRA_SPACING_FOR_LABEL = 50
-FONTSIZE = 9
 
 # global variables
 _g_host_counter = 0
 _g_parasite_counter = 0
 
-def render(host_dict: dict, parasite_dict: dict, tip_mapping: dict, show_internal_labels: bool, ax: plt.Axes = None) \
-        -> plot_tools.FigureWrapper:
+def render(
+    host_dict: dict,
+    parasite_dict: dict,
+    tip_mapping: dict,
+    show_internal_labels: bool,
+    ax: plt.Axes = None,
+    node_font_size = 9,
+    ) -> plot_tools.FigureWrapper:
     """
     Render tanglegram
     :param host_dict - host tree (dictionary representation)
@@ -38,8 +43,18 @@ def render(host_dict: dict, parasite_dict: dict, tip_mapping: dict, show_interna
     fig = plot_tools.FigureWrapper("Host | Parasite", axes=ax)
     host_tree = utils.dict_to_tree(host_dict, tree.TreeType.HOST)
     parasite_tree = utils.dict_to_tree(parasite_dict, tree.TreeType.PARASITE)
-    _render_helper_host(fig, host_tree.root_node, show_internal_labels)
-    _render_helper_parasite(fig, parasite_tree.root_node, show_internal_labels)
+    _render_helper_host(
+        fig=fig, 
+        node=host_tree.root_node, 
+        show_internal_labels=show_internal_labels, 
+        node_font_size=node_font_size
+    )
+    _render_helper_parasite(
+        fig=fig, 
+        node=parasite_tree.root_node, 
+        show_internal_labels=show_internal_labels,
+        node_font_size=node_font_size
+    )
 
     host_dict = {}
     for host in host_tree.leaf_list():
@@ -53,7 +68,7 @@ def render(host_dict: dict, parasite_dict: dict, tip_mapping: dict, show_interna
                  col=render_settings.GRAY, linestyle='--')
     return fig
 
-def _render_helper_host(fig, node, show_internal_labels):
+def _render_helper_host(fig, node, show_internal_labels, node_font_size):
     """
     Render helper for host tree
     """
@@ -70,12 +85,12 @@ def _render_helper_host(fig, node, show_internal_labels):
 
         # plot node using leaf_layout
         plot_loc = (leaf_layout.col, leaf_layout.row)
-        textbox = fig.text(plot_loc, node.name, size=FONTSIZE, col=render_settings.BLUE, h_a='right')
+        fig.text(plot_loc, node.name, size=node_font_size, col=render_settings.BLUE, h_a='right')
 
     else:
         # recursively call helper function on child nodes
-        _render_helper_host(fig, node.left_node, show_internal_labels)
-        _render_helper_host(fig, node.right_node, show_internal_labels)
+        _render_helper_host(fig, node.left_node, show_internal_labels, node_font_size)
+        _render_helper_host(fig, node.right_node, show_internal_labels, node_font_size)
 
         # get layouts for child nodes to determine position of current node
         right_layout = node.right_node.layout
@@ -93,7 +108,7 @@ def _render_helper_host(fig, node, show_internal_labels):
         # plot node using node_layout
         current_loc = (node.layout.col, node.layout.row)
         if show_internal_labels:
-            fig.text(current_loc, node.name, size=FONTSIZE, col=render_settings.BLUE, h_a='left')
+            fig.text(current_loc, node.name, size=node_font_size, col=render_settings.BLUE, h_a='left')
 
         # draw line from current node to left node
         left_loc = (left_layout.col, left_layout.row)
@@ -106,7 +121,7 @@ def _render_helper_host(fig, node, show_internal_labels):
         fig.line((node.layout.col, right_layout.row), right_loc, col=render_settings.BLACK)
 
 
-def _render_helper_parasite(fig, node, show_internal_labels):
+def _render_helper_parasite(fig, node, show_internal_labels, node_font_size):
     """
     Render helper for parasite tree
     """
@@ -122,12 +137,12 @@ def _render_helper_parasite(fig, node, show_internal_labels):
 
         # plot node using leaf_layout
         plot_loc = (leaf_layout.col, leaf_layout.row)
-        fig.text(plot_loc, node.name, size=FONTSIZE, col=render_settings.BLUE, h_a='left')
+        fig.text(plot_loc, node.name, size=node_font_size, col=render_settings.BLUE, h_a='left')
 
     else:
         # recursively call helper funciton on child nodes
-        _render_helper_parasite(fig, node.left_node, show_internal_labels)
-        _render_helper_parasite(fig, node.right_node, show_internal_labels)
+        _render_helper_parasite(fig, node.left_node, show_internal_labels, node_font_size)
+        _render_helper_parasite(fig, node.right_node, show_internal_labels, node_font_size)
 
         # get layouts for child nodes to determine position of current node
         right_layout = node.right_node.layout
@@ -145,7 +160,7 @@ def _render_helper_parasite(fig, node, show_internal_labels):
         # plot node using node_layout
         current_loc = (node.layout.col, node.layout.row)
         if show_internal_labels:
-            fig.text(current_loc, node.name, size=FONTSIZE, col=render_settings.BLUE, h_a='right')
+            fig.text(current_loc, node.name, size=node_font_size, col=render_settings.BLUE, h_a='right')
 
         # draw line from current node to left node
         left_loc = (left_layout.col, left_layout.row)

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -128,7 +128,7 @@ class App(tk.Frame):
         self.host_tree_info = tk.Label(self.input_info_frame)
         self.parasite_tree_info = tk.Label(self.input_info_frame)
         self.mapping_info = tk.Label(self.input_info_frame)
-        self.recon_input = empress.ReconInputWrapper()
+        App.recon_input = empress.ReconInputWrapper()
         self.first_time_loading_files = True
         self.need_to_reset = True
 
@@ -226,39 +226,39 @@ class App(tk.Frame):
     
     def refresh_when_reload_host(self):
         if self.first_time_loading_files:
-            self.recon_input.read_host(self.host_file_path)
+            App.recon_input.read_host(self.host_file_path)
             self.host_tree_info.destroy()
         else:
             if self.need_to_reset:
                 self.reset()
-            self.recon_input.read_host(self.host_file_path)
+            App.recon_input.read_host(self.host_file_path)
             self.host_tree_info.destroy()
             self.parasite_tree_info.destroy()
             self.mapping_info.destroy()
     
     def refresh_when_reload_parasite(self):
         if self.first_time_loading_files:
-            self.recon_input.read_parasite(self.parasite_file_path)
+            App.recon_input.read_parasite(self.parasite_file_path)
             self.parasite_tree_info.destroy()
         else:
             if self.need_to_reset:
                 self.reset()
-            self.recon_input.read_host(self.host_file_path)
-            self.recon_input.read_parasite(self.parasite_file_path)
+            App.recon_input.read_host(self.host_file_path)
+            App.recon_input.read_parasite(self.parasite_file_path)
             self.parasite_tree_info.destroy()
             self.mapping_info.destroy()
     
     def refresh_when_reload_mapping(self):
         if self.first_time_loading_files:
-            self.recon_input.read_mapping(self.mapping_file_path)
+            App.recon_input.read_mapping(self.mapping_file_path)
             self.mapping_info.destroy()
             self.first_time_loading_files = False
         else:
             if self.need_to_reset:
                 self.reset()
-            self.recon_input.read_host(self.host_file_path)
-            self.recon_input.read_parasite(self.parasite_file_path)
-            self.recon_input.read_mapping(self.mapping_file_path)
+            App.recon_input.read_host(self.host_file_path)
+            App.recon_input.read_parasite(self.parasite_file_path)
+            App.recon_input.read_mapping(self.mapping_file_path)
             self.mapping_info.destroy()  
             self.need_to_reset = True  
 
@@ -266,7 +266,7 @@ class App(tk.Frame):
         App.recon_graph = None
         App.clusters_list = []
         App.medians = None
-        self.recon_input = empress.ReconInputWrapper()
+        App.recon_input = empress.ReconInputWrapper()
         self.view_cost_space_btn.configure(state=tk.DISABLED)
         self.view_tanglegram_btn.configure(state=tk.DISABLED)
 
@@ -345,7 +345,7 @@ class App(tk.Frame):
                                                        filetypes=[("Newick Trees", "*.nwk *.newick *.tree"), ("All Files", "*")])
             if input_file:
                 try:
-                    self.recon_input.read_host(input_file)
+                    App.recon_input.read_host(input_file)
                 except Exception as e:
                     messagebox.showinfo("Warning", "Error: " + str(e))
                     return
@@ -365,7 +365,7 @@ class App(tk.Frame):
                                                        filetypes=[("Newick Trees", "*.nwk *.newick *.tree"), ("All Files", "*")])
             if input_file:
                 try:
-                    self.recon_input.read_parasite(input_file)
+                    App.recon_input.read_parasite(input_file)
                 except Exception as e:
                     messagebox.showinfo("Warning", "Error: " + str(e))
                     return
@@ -382,14 +382,14 @@ class App(tk.Frame):
                                                        filetypes=[("Tip mapping", "*.mapping"), ("All Files", "*")])
             if input_file:
                 try:
-                    self.recon_input.read_mapping(input_file)
+                    App.recon_input.read_mapping(input_file)
                 except Exception as e:
                     messagebox.showinfo("Warning", "Error: " + str(e))
                     return
                 self.mapping_file_path = input_file
                 self.refresh_when_reload_mapping()
                 self.update_mapping_info()
-                if self.recon_input.is_complete():
+                if App.recon_input.is_complete():
                     self.view_tanglegram_btn.configure(state=tk.NORMAL)
                     self.view_cost_space_btn.configure(state=tk.NORMAL)
                     self.compute_reconciliations_btn.configure(state=tk.NORMAL)
@@ -399,10 +399,10 @@ class App(tk.Frame):
     def compute_tree_tips(self, tree_type):
         """Compute the number of tips for the host tree and parasite tree inputs."""
         if tree_type == "host tree":
-            host_tree_object = dict_to_tree(self.recon_input.host_dict, tree.TreeType.HOST)
+            host_tree_object = dict_to_tree(App.recon_input.host_dict, tree.TreeType.HOST)
             return len(host_tree_object.leaf_list())
         elif tree_type == "parasite tree":
-            parasite_tree_object = dict_to_tree(self.recon_input.parasite_dict, tree.TreeType.PARASITE)
+            parasite_tree_object = dict_to_tree(App.recon_input.parasite_dict, tree.TreeType.PARASITE)
             return len(parasite_tree_object.leaf_list())
 
     def update_host_info(self):
@@ -430,20 +430,11 @@ class App(tk.Frame):
         # Bring the new tkinter window to the front
         # https://stackoverflow.com/a/53644859/13698076
         self.tanglegram_window.attributes('-topmost', True)
+
         self.tanglegram_window.focus_force()
         self.tanglegram_window.bind('<FocusIn>', self.bring_to_front)
         # Creates a new frame
-        tanglegram_frame = tk.Frame(self.tanglegram_window)
-        tanglegram_frame.pack(fill=tk.BOTH, expand=1)
-        tanglegram_frame.pack_propagate(False)
-        fig = self.recon_input.draw()
-        canvas = FigureCanvasTkAgg(fig, tanglegram_frame)
-        canvas.draw()
-        canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        # The toolbar allows the user to zoom in/out, drag the graph and save the graph
-        toolbar = NavigationToolbar2Tk(canvas, tanglegram_frame)
-        toolbar.update()
-        canvas.get_tk_widget().pack(side=tk.TOP)
+        TanglegramWindow(self.tanglegram_window)
 
     def plot_cost_regions(self):
         """Plot the cost regions using matplotlib and embed the graph in a tkinter window."""
@@ -461,7 +452,7 @@ class App(tk.Frame):
         plt_frame = tk.Frame(self.cost_space_window)
         plt_frame.pack(fill=tk.BOTH, expand=1)
         plt_frame.pack_propagate(False)
-        cost_regions = self.recon_input.compute_cost_regions(0.5, 10, 0.5, 10)
+        cost_regions = App.recon_input.compute_cost_regions(0.5, 10, 0.5, 10)
         fig = cost_regions.draw()  # creates matplotlib figure
         canvas = FigureCanvasTkAgg(fig, plt_frame)
         canvas.draw()
@@ -590,7 +581,7 @@ class App(tk.Frame):
 
     def display_recon_information(self):
         """Display numeric reconciliation results and close unnecessary windows."""
-        App.recon_graph = self.recon_input.reconcile(self.dup_cost, self.trans_cost, self.loss_cost)
+        App.recon_graph = App.recon_input.reconcile(self.dup_cost, self.trans_cost, self.loss_cost)
         self.recon_count = App.recon_graph.n_recon
         self.cospec_count, self.dup_count, self.trans_count, self.loss_count = App.recon_graph.median().count_events()
         if not self.recon_info_displayed:
@@ -814,6 +805,83 @@ class App(tk.Frame):
         if type(event.widget).__name__ == 'Tk':
             event.widget.attributes('-topmost', False)
 
+class TanglegramWindow(tk.Frame):
+    def __init__(self, master):
+        super().__init__(master)
+        self.master = master
+        self.master.grid_rowconfigure(0, weight=5)
+        self.master.grid_rowconfigure(1, weight=1)
+        self.master.grid_columnconfigure(0, weight=1)
+
+        self.tanglegram_frame = tk.Frame(self.master)
+        self.tanglegram_frame.grid(row=0, column=0, sticky="nsew")
+        self.tanglegram_frame.grid_propagate(False)
+
+        self.config_frame = tk.Frame(self.master)
+        self.config_frame.grid(row=1, column=0)
+        self.config_frame.grid_propagate(False)
+
+        self.font_size_var = tk.IntVar(value=9)
+        self.font_size = 9
+        self.create_font_size_editor()
+
+        self.draw_tanglegram()
+    
+    def create_font_size_editor(self):
+        font_size_label = tk.Label(
+            master=self.config_frame, 
+            text="Font size:"
+        )
+        font_size_label.pack(side=tk.LEFT)
+
+        self.font_size_entry = CustomEntry(
+            master=self.config_frame, 
+            width=3, 
+            textvariable=self.font_size_var
+        )
+        self.font_size_entry.set_border_color("green")
+        validatecommand = (self.register(self.font_size_validate_and_get), '%P')
+        self.font_size_entry.validate(validate="key", validatecommand=validatecommand)
+        self.font_size_entry.pack(side=tk.LEFT)
+
+        redraw_button = tk.Button(
+            master=self.config_frame,
+            text="Redraw tanglegram", 
+            command=self.update_tanglegram
+        )
+        redraw_button.pack(side=tk.LEFT)
+
+    def font_size_validate_and_get(self, input_after_change: str):
+        try:
+            input_val = int(input_after_change)
+            if input_val >= 0:
+                self.font_size = input_val
+                self.font_size_entry.set_border_color("green")
+            else: 
+                self.font_size_entry.set_border_color("red")
+        except ValueError:
+            self.font_size_entry.set_border_color("red")
+        return True  # return True means allowing the change to happen
+    
+    def draw_tanglegram(self):
+        self.fig = App.recon_input.draw(
+            node_font_size=self.font_size
+        )
+        self.canvas = FigureCanvasTkAgg(self.fig, self.tanglegram_frame)
+        self.canvas.draw()
+        self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        # The toolbar allows the user to zoom in/out, drag the graph and save the graph
+        self.toolbar = NavigationToolbar2Tk(
+            canvas=self.canvas, 
+            window=self.tanglegram_frame
+        )
+        self.toolbar.update()
+    
+    def update_tanglegram(self):
+        self.canvas.get_tk_widget().destroy()
+        self.toolbar.destroy()
+        self.draw_tanglegram()
+
 # View reconciliation space - Clusters
 class SolutionSpaceWindow(tk.Frame):
     def __init__(self, master):
@@ -875,7 +943,6 @@ class ReconciliationsOneMPRWindow(tk.Frame):
         # The toolbar allows the user to zoom in/out, drag the graph and save the graph
         self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
         self.toolbar.update()
-        self.canvas.get_tk_widget().pack(side=tk.TOP)
 
     def create_checkboxes(self):
         self.show_internal_node_names_boolean = tk.BooleanVar()
@@ -985,8 +1052,8 @@ class PValueHistogramWindow(tk.Frame):
         canvas.get_tk_widget().pack(side=tk.TOP)
 
 class CustomEntry(tk.Frame):
-    def __init__(self, parent, *args, **kwargs):
-        tk.Frame.__init__(self, parent)
+    def __init__(self, master, *args, **kwargs):
+        tk.Frame.__init__(self, master)
         self.entry = tk.Entry(self, *args, **kwargs)
         self.entry.pack(fill="both", expand=tk.TRUE, padx=1, pady=1)
         self.get = self.entry.get


### PR DESCRIPTION
- Add a font size input text box in the tanglegram window that allows changing the font size of node names. 
- Add a redraw button for user to click after changing the font size.
- Add the same font size text box and redraw button to the reconciliation window.

| Smaller Font  | Larger Font |
| ------------- | ------------- |
| <img width="400" alt="Screen Shot 2021-06-12 at 2 28 20 PM" src="https://user-images.githubusercontent.com/19219105/121773597-24a98b00-cba7-11eb-9301-1a50bd0edf9b.png"> | <img width="400" alt="Screen Shot 2021-06-12 at 2 27 27 PM" src="https://user-images.githubusercontent.com/19219105/121773605-2ffcb680-cba7-11eb-8b84-d897cc5a67ed.png"> |
| <img width="400" alt="Screen Shot 2021-06-12 at 5 44 20 PM" src="https://user-images.githubusercontent.com/19219105/121773632-56225680-cba7-11eb-8675-ff59a170bc4a.png"> | <img width="400" alt="Screen Shot 2021-06-12 at 5 44 41 PM" src="https://user-images.githubusercontent.com/19219105/121773642-61758200-cba7-11eb-8da9-1e7238d2b367.png"> |