### PR TITLE
GUI: Add "Display legend" checkbox in reconciliation window

### DIFF
--- a/empress/__init__.py
+++ b/empress/__init__.py
@@ -96,6 +96,7 @@ class ReconciliationWrapper(Drawable):
                 axes: plt.Axes,
                 show_internal_labels: bool = False,
                 show_freq: bool = True,
+                show_legend: bool = False,
                 node_font_size: float = 0.3,
                 ):
         recon_viewer.render(
@@ -105,6 +106,7 @@ class ReconciliationWrapper(Drawable):
             self.event_frequencies,
             show_internal_labels=show_internal_labels,
             show_freq=show_freq,
+            show_legend=show_legend,
             node_font_size=node_font_size,
             axes=axes
         )

--- a/empress/recon_vis/recon_viewer.py
+++ b/empress/recon_vis/recon_viewer.py
@@ -18,7 +18,7 @@ def render(host_dict: dict,
            event_frequencies: Dict[tuple, float] = None,
            show_internal_labels: bool = False,
            show_freq: bool = False,
-           show_legend: bool = True,
+           show_legend: bool = False,
            node_font_size: float = 0.3,
            axes: Union[plt.Axes, None] = None,
            ):

--- a/empress_gui.py
+++ b/empress_gui.py
@@ -860,7 +860,7 @@ class TanglegramWindow(tk.Frame):
     
     def draw_tanglegram(self):
         self.fig = App.recon_input.draw(
-            node_font_size=self.font_size
+            node_font_size=self.font_size.get()
         )
         self.canvas = FigureCanvasTkAgg(self.fig, self.tanglegram_frame)
         self.canvas.draw()
@@ -935,6 +935,9 @@ class ReconciliationFrame(tk.Frame):
         self.show_event_frequencies = tk.BooleanVar(value=True)
         self.create_show_event_frequencies_checkbox()
 
+        self.show_legend = tk.BooleanVar(value=False)
+        self.create_show_legend_checkbox()
+
         self.font_size_var = tk.DoubleVar(value=0.3)
         self.font_size = 0.3
         self.create_font_size_editor()
@@ -956,6 +959,14 @@ class ReconciliationFrame(tk.Frame):
             variable=self.show_event_frequencies,
             command=self.update_reconciliation)
         show_event_frequencies_checkbutton.pack(side=tk.LEFT)
+
+    def create_show_legend_checkbox(self):
+        show_legend_checkbutton = tk.Checkbutton(
+            master=self.config_frame,
+            text="Display legend",
+            variable=self.show_legend,
+            command=self.update_reconciliation)
+        show_legend_checkbutton.pack(side=tk.LEFT)
 
     def create_font_size_editor(self):
         font_size_label = tk.Label(
@@ -995,8 +1006,9 @@ class ReconciliationFrame(tk.Frame):
 
     def draw_reconciliation(self):
         self.reconciliation_fig = self.reconciliation.draw(
-            show_internal_labels=self.show_internal_node_names,
-            show_freq=self.show_event_frequencies,
+            show_internal_labels=self.show_internal_node_names.get(),
+            show_freq=self.show_event_frequencies.get(),
+            show_legend=self.show_legend.get(),
             node_font_size=self.font_size
         )
         self.canvas = FigureCanvasTkAgg(self.reconciliation_fig, self.reconciliation_frame)


### PR DESCRIPTION
Add "Display legend" checkbox in reconciliation window. Default is false (no legend).

| Display legend = False | Display legend  = True |
|---|---|
| <img width="400" alt="Screen Shot 2021-06-12 at 8 42 46 PM" src="https://user-images.githubusercontent.com/19219105/121778062-59294100-cbbf-11eb-9247-b869d16cca90.png"> | <img width="400" alt="Screen Shot 2021-06-12 at 8 42 52 PM" src="https://user-images.githubusercontent.com/19219105/121778069-5e868b80-cbbf-11eb-99c7-bd1f79090688.png"> |

Resolves #238.

Fixed a bug introduced in #240 where the `Display internal node names` and `Display event frequencies` buttons on reconciliation windows do not work.