### PR TITLE
Add executable permission to linux app

### DIFF
--- a/.github/workflows/linux-build-gui-executable.yml
+++ b/.github/workflows/linux-build-gui-executable.yml
@@ -39,7 +39,8 @@ jobs:
         python3.7 -m pipenv install --dev
     - name: Create linux app
       run: |
-        python3.7 -m pipenv run pyinstaller pyinstaller_spec/empress_gui_app.spec
+        sudo python3.7 -m pipenv run pyinstaller pyinstaller_spec/empress_gui_app.spec
+        sudo chmod +x ./dist/empress/empress_gui
     - name: Upload executable
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Add executable permission to eMPRess app on Linux so that users don't have to run  right-click on **empress_gui** file, and click Properties, then select the Permissions tab. Then, check the box that says Allow executing file as a program. (or run `chmod +x ./empress_gui`)